### PR TITLE
Structured logging for core

### DIFF
--- a/core/adapters/http/adapter.go
+++ b/core/adapters/http/adapter.go
@@ -35,13 +35,19 @@ func (a *Adapter) Send(p core.Packet, r ...core.Recipient) (core.Packet, error) 
 	// Generate payload from core packet
 	m, err := json.Marshal(p.Metadata)
 	if err != nil {
+		a.Ctx.WithError(err).Warn("Invalid Packet")
 		return core.Packet{}, ErrInvalidPacket
 	}
 	pl, err := p.Payload.MarshalBinary()
 	if err != nil {
+		a.Ctx.WithError(err).Warn("Invalid Packet")
 		return core.Packet{}, ErrInvalidPacket
 	}
 	payload := fmt.Sprintf(`{"payload":"%s","metadata":%s}`, base64.StdEncoding.EncodeToString(pl), m)
+
+	devAddr, _ := p.DevAddr()
+	ctx := a.Ctx.WithField("devAddr", devAddr)
+	ctx.Debug("Sending Packet")
 
 	// Prepare ground for parrallel http request
 	nb := len(r)
@@ -54,7 +60,10 @@ func (a *Adapter) Send(p core.Packet, r ...core.Recipient) (core.Packet, error) 
 	for _, recipient := range r {
 		go func(recipient core.Recipient) {
 			defer wg.Done()
-			a.Ctx.WithField("recipient", recipient).Debug("POST Request")
+
+			ctx := ctx.WithField("recipient", recipient)
+			ctx.Debug("POST Request")
+
 			buf := new(bytes.Buffer)
 			buf.Write([]byte(payload))
 
@@ -67,6 +76,7 @@ func (a *Adapter) Send(p core.Packet, r ...core.Recipient) (core.Packet, error) 
 
 			// Check response code
 			if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusCreated {
+				ctx.WithField("response", resp.StatusCode).Warn("Unexpected response")
 				cherr <- fmt.Errorf("Unexpected response from server: %s (%d)", resp.Status, resp.StatusCode)
 				return
 			}
@@ -97,11 +107,14 @@ func (a *Adapter) Send(p core.Packet, r ...core.Recipient) (core.Packet, error) 
 	// Collect errors
 	var errors []error
 	for i := 0; i < len(cherr); i += 1 {
-		errors = append(errors, <-cherr)
+		err := <-cherr
+		ctx.WithError(err).Error("POST Failed")
+		errors = append(errors, err)
 	}
 
 	// Check responses
 	if len(chresp) > 1 {
+		ctx.WithField("response_count", len(chresp)).Error("Received Too many positive answers")
 		return core.Packet{}, fmt.Errorf("Several positive answer from servers")
 	}
 
@@ -113,6 +126,7 @@ func (a *Adapter) Send(p core.Packet, r ...core.Recipient) (core.Packet, error) 
 		if errors != nil {
 			return core.Packet{}, fmt.Errorf("Errors: %v", errors)
 		}
+		ctx.Error("No response packet available")
 		return core.Packet{}, fmt.Errorf("No response packet available")
 	}
 }

--- a/core/adapters/http/adapter.go
+++ b/core/adapters/http/adapter.go
@@ -20,13 +20,13 @@ var ErrInvalidPort = fmt.Errorf("The given port is invalid")
 var ErrInvalidPacket = fmt.Errorf("The given packet is invalid")
 
 type Adapter struct {
-	Ctx log.Interface
+	ctx log.Interface
 }
 
 // NewAdapter constructs and allocate a new Broker <-> Handler http adapter
 func NewAdapter(ctx log.Interface) (*Adapter, error) {
 	return &Adapter{
-		Ctx: ctx,
+		ctx: ctx,
 	}, nil
 }
 
@@ -35,18 +35,18 @@ func (a *Adapter) Send(p core.Packet, r ...core.Recipient) (core.Packet, error) 
 	// Generate payload from core packet
 	m, err := json.Marshal(p.Metadata)
 	if err != nil {
-		a.Ctx.WithError(err).Warn("Invalid Packet")
+		a.ctx.WithError(err).Warn("Invalid Packet")
 		return core.Packet{}, ErrInvalidPacket
 	}
 	pl, err := p.Payload.MarshalBinary()
 	if err != nil {
-		a.Ctx.WithError(err).Warn("Invalid Packet")
+		a.ctx.WithError(err).Warn("Invalid Packet")
 		return core.Packet{}, ErrInvalidPacket
 	}
 	payload := fmt.Sprintf(`{"payload":"%s","metadata":%s}`, base64.StdEncoding.EncodeToString(pl), m)
 
 	devAddr, _ := p.DevAddr()
-	ctx := a.Ctx.WithField("devAddr", devAddr)
+	ctx := a.ctx.WithField("devAddr", devAddr)
 	ctx.Debug("Sending Packet")
 
 	// Prepare ground for parrallel http request

--- a/core/adapters/http/adapter_test.go
+++ b/core/adapters/http/adapter_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/TheThingsNetwork/ttn/lorawan"
 	"github.com/TheThingsNetwork/ttn/utils/pointer"
 	. "github.com/TheThingsNetwork/ttn/utils/testing"
-	"github.com/apex/log"
 )
 
 // Send(p core.Packet, r ...core.Recipient) error
@@ -41,10 +40,7 @@ func TestSend(t *testing.T) {
 	s := genMockServer(3100)
 
 	// Logging
-	log.SetHandler(NewLogHandler(t))
-	ctx := log.WithFields(log.Fields{
-		"tag": "Adapter",
-	})
+	ctx := GetLogger(t, "Adapter")
 
 	adapter, err := NewAdapter(ctx)
 	if err != nil {

--- a/core/adapters/http/broadcast/broadcast.go
+++ b/core/adapters/http/broadcast/broadcast.go
@@ -18,6 +18,8 @@ import (
 )
 
 type Adapter struct {
+	ctx log.Interface
+
 	*httpadapter.Adapter
 	recipients    []core.Recipient
 	registrations chan core.Registration
@@ -38,6 +40,8 @@ func NewAdapter(recipients []core.Recipient, ctx log.Interface) (*Adapter, error
 	}
 
 	return &Adapter{
+		ctx: ctx,
+
 		Adapter:       adapter,
 		recipients:    recipients,
 		registrations: make(chan core.Registration, len(recipients)),
@@ -85,7 +89,7 @@ func (a *Adapter) broadcast(p core.Packet) (core.Packet, error) {
 		go func(recipient core.Recipient) {
 			defer wg.Done()
 
-			ctx := a.Ctx.WithField("recipient", recipient)
+			ctx := a.ctx.WithField("recipient", recipient)
 
 			ctx.Debug("POST Request")
 

--- a/core/adapters/http/broadcast/broadcast_test.go
+++ b/core/adapters/http/broadcast/broadcast_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/TheThingsNetwork/ttn/lorawan"
 	"github.com/TheThingsNetwork/ttn/utils/pointer"
 	. "github.com/TheThingsNetwork/ttn/utils/testing"
-	"github.com/apex/log"
 )
 
 func TestSend(t *testing.T) {
@@ -71,10 +70,7 @@ func TestSend(t *testing.T) {
 	}
 
 	// Logging
-	log.SetHandler(NewLogHandler(t))
-	ctx := log.WithFields(log.Fields{
-		"tag": "Adapter",
-	})
+	ctx := GetLogger(t, "Adapter")
 
 	// Build
 	adapter, err := NewAdapter(recipients, ctx)

--- a/core/adapters/http/pubsub/pubsub.go
+++ b/core/adapters/http/pubsub/pubsub.go
@@ -13,6 +13,8 @@ import (
 )
 
 type Adapter struct {
+	ctx log.Interface
+
 	*httpadapter.Adapter
 	Parser
 	registrations chan regReq
@@ -40,6 +42,8 @@ func NewAdapter(port uint, parser Parser, ctx log.Interface) (*Adapter, error) {
 	}
 
 	a := &Adapter{
+		ctx: ctx,
+
 		Adapter:       adapter,
 		Parser:        parser,
 		registrations: make(chan regReq),
@@ -68,9 +72,9 @@ func (a *Adapter) listenRegistration(port uint) {
 		Addr:    fmt.Sprintf("0.0.0.0:%d", port),
 		Handler: serveMux,
 	}
-	a.Ctx.WithField("port", port).Info("Starting Server")
+	a.ctx.WithField("port", port).Info("Starting Server")
 	err := server.ListenAndServe()
-	a.Ctx.WithError(err).Warn("HTTP connection lost")
+	a.ctx.WithError(err).Warn("HTTP connection lost")
 }
 
 // fail logs the given failure and sends an appropriate response to the client
@@ -81,7 +85,7 @@ func (a *Adapter) badRequest(w http.ResponseWriter, msg string) {
 
 // handle request [PUT] on /end-device/:devAddr
 func (a *Adapter) handlePutEndDevice(w http.ResponseWriter, req *http.Request) {
-	ctx := a.Ctx.WithField("sender", req.RemoteAddr)
+	ctx := a.ctx.WithField("sender", req.RemoteAddr)
 
 	ctx.Debug("Receiving new registration request")
 	// Check the http method

--- a/core/adapters/http/pubsub/pubsub_test.go
+++ b/core/adapters/http/pubsub/pubsub_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/TheThingsNetwork/ttn/core"
 	"github.com/TheThingsNetwork/ttn/lorawan"
 	. "github.com/TheThingsNetwork/ttn/utils/testing"
-	"github.com/apex/log"
 )
 
 // NextRegistration() (core.Registration, core.AckNacker, error)
@@ -61,10 +60,7 @@ func TestNextRegistration(t *testing.T) {
 	}
 
 	// Logging
-	log.SetHandler(NewLogHandler(t))
-	ctx := log.WithFields(log.Fields{
-		"tag": "Adapter",
-	})
+	ctx := GetLogger(t, "Adapter")
 
 	adapter, err := NewAdapter(3021, HandlerParser{}, ctx)
 	client := &client{adapter: "0.0.0.0:3021"}

--- a/core/adapters/semtech/build_utilities_test.go
+++ b/core/adapters/semtech/build_utilities_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/TheThingsNetwork/ttn/semtech"
 	"github.com/TheThingsNetwork/ttn/utils/pointer"
 	. "github.com/TheThingsNetwork/ttn/utils/testing"
-	"github.com/apex/log"
 )
 
 // ----- build utilities
@@ -74,10 +73,7 @@ func (s mockServer) send(p semtech.Packet) semtech.Packet {
 // in a select for timeout)
 func genAdapter(t *testing.T, port uint) (*Adapter, chan interface{}) {
 	// Logging
-	log.SetHandler(NewLogHandler(t))
-	ctx := log.WithFields(log.Fields{
-		"tag": "Adapter",
-	})
+	ctx := GetLogger(t, "Adapter")
 
 	adapter, err := NewAdapter(port, ctx)
 	if err != nil {

--- a/core/components/broker.go
+++ b/core/components/broker.go
@@ -12,7 +12,7 @@ import (
 )
 
 type Broker struct {
-	Ctx log.Interface
+	ctx log.Interface
 	db  brokerStorage
 }
 
@@ -24,7 +24,7 @@ func NewBroker(ctx log.Interface) (*Broker, error) {
 	}
 
 	return &Broker{
-		Ctx: ctx,
+		ctx: ctx,
 		db:  localDB,
 	}, nil
 }
@@ -33,11 +33,11 @@ func (b *Broker) HandleUp(p core.Packet, an core.AckNacker, adapter core.Adapter
 	// 1. Lookup for entries for the associated device
 	devAddr, err := p.DevAddr()
 	if err != nil {
-		b.Ctx.Warn("Uplink Invalid")
+		b.ctx.Warn("Uplink Invalid")
 		an.Nack()
 		return ErrInvalidPacket
 	}
-	ctx := b.Ctx.WithField("devAddr", devAddr)
+	ctx := b.ctx.WithField("devAddr", devAddr)
 	entries, err := b.db.lookup(devAddr)
 	switch err {
 	case nil:
@@ -89,7 +89,7 @@ func (b *Broker) Register(r core.Registration, an core.AckNacker) error {
 	url, okUrl := r.Recipient.Address.(string)
 	nwsKey, okNwsKey := r.Options.(lorawan.AES128Key)
 
-	ctx := b.Ctx.WithField("devAddr", r.DevAddr)
+	ctx := b.ctx.WithField("devAddr", r.DevAddr)
 
 	if !(okId && okUrl && okNwsKey) {
 		ctx.Warn("Invalid Registration")

--- a/core/components/broker.go
+++ b/core/components/broker.go
@@ -33,13 +33,16 @@ func (b *Broker) HandleUp(p core.Packet, an core.AckNacker, adapter core.Adapter
 	// 1. Lookup for entries for the associated device
 	devAddr, err := p.DevAddr()
 	if err != nil {
+		b.Ctx.Warn("Uplink Invalid")
 		an.Nack()
 		return ErrInvalidPacket
 	}
+	ctx := b.Ctx.WithField("devAddr", devAddr)
 	entries, err := b.db.lookup(devAddr)
 	switch err {
 	case nil:
 	case ErrDeviceNotFound:
+		ctx.Warn("Uplink device not found")
 		return an.Nack()
 	default:
 		an.Nack()
@@ -59,12 +62,12 @@ func (b *Broker) HandleUp(p core.Packet, an core.AckNacker, adapter core.Adapter
 				Id:      entry.Id,
 				Address: entry.Url,
 			}
-			b.Ctx.WithFields(log.Fields{"devAddr": devAddr, "handler": handler}).Debug("Associated device with handler")
+			ctx.WithField("handler", handler).Debug("Associated device with handler")
 			break
 		}
 	}
 	if handler == nil {
-		b.Ctx.WithField("devAddr", devAddr).Warn("Could not find handler for device")
+		ctx.Warn("Could not find handler for device")
 		return an.Nack()
 	}
 
@@ -86,15 +89,21 @@ func (b *Broker) Register(r core.Registration, an core.AckNacker) error {
 	url, okUrl := r.Recipient.Address.(string)
 	nwsKey, okNwsKey := r.Options.(lorawan.AES128Key)
 
+	ctx := b.Ctx.WithField("devAddr", r.DevAddr)
+
 	if !(okId && okUrl && okNwsKey) {
+		ctx.Warn("Invalid Registration")
 		an.Nack()
 		return ErrInvalidRegistration
 	}
 
 	entry := brokerEntry{Id: id, Url: url, NwsKey: nwsKey}
 	if err := b.db.store(r.DevAddr, entry); err != nil {
+		ctx.WithError(err).Error("Failed Registration")
 		an.Nack()
 		return err
 	}
+
+	ctx.Debug("Successful Registration")
 	return an.Ack()
 }

--- a/utils/testing/log_handler.go
+++ b/utils/testing/log_handler.go
@@ -18,7 +18,7 @@ const (
 	green  = 32
 	yellow = 33
 	blue   = 34
-	gray   = 37
+	gray   = 90
 )
 
 // Colors mapping.

--- a/utils/testing/testing.go
+++ b/utils/testing/testing.go
@@ -8,7 +8,17 @@ package testing
 import (
 	"fmt"
 	"testing"
+
+	"github.com/apex/log"
 )
+
+func GetLogger(t *testing.T, tag string) log.Interface {
+	logger := &log.Logger{
+		Handler: NewLogHandler(t),
+		Level:   log.DebugLevel,
+	}
+	return logger.WithField("tag", "Adapter")
+}
 
 // Ok displays a green check symbol
 func Ok(t *testing.T, tag string) {


### PR DESCRIPTION
This PR adds structured logging to core components.
As @KtorZ was planning on rewriting the simulator, I didn't add structured logging to that. When he finishes that, we can remove `utils/log`.

Resolves #7 when merged.
