### PR TITLE
Collecting and Showing live metrics from running components

### DIFF
--- a/core/adapters/http/adapter.go
+++ b/core/adapters/http/adapter.go
@@ -139,7 +139,9 @@ func (a *Adapter) Send(p core.Packet, r ...core.Recipient) (core.Packet, error) 
 	}
 
 	// Wait for each request to be done, and return
+	stats.IncCounter("http_adapter.waiting_for_send")
 	wg.Wait()
+	stats.DecCounter("http_adapter.waiting_for_send")
 
 	// Collect errors
 	var errs []error

--- a/core/adapters/http/adapter.go
+++ b/core/adapters/http/adapter.go
@@ -17,6 +17,7 @@ import (
 	"github.com/TheThingsNetwork/ttn/core/adapters/http/parser"
 	. "github.com/TheThingsNetwork/ttn/core/errors"
 	"github.com/TheThingsNetwork/ttn/utils/errors"
+	"github.com/TheThingsNetwork/ttn/utils/stats"
 	"github.com/apex/log"
 )
 
@@ -59,6 +60,9 @@ func NewAdapter(port uint, parser parser.PacketParser, ctx log.Interface) (*Adap
 
 // Send implements the core.Adapter interface
 func (a *Adapter) Send(p core.Packet, r ...core.Recipient) (core.Packet, error) {
+	stats.MarkMeter("http_adapter.send")
+	stats.UpdateHistogram("http_adapter.send_recipients", int64(len(r)))
+
 	// Generate payload from core packet
 	m, err := json.Marshal(p.Metadata)
 	if err != nil {

--- a/core/adapters/http/broadcast/broadcast.go
+++ b/core/adapters/http/broadcast/broadcast.go
@@ -17,6 +17,7 @@ import (
 	httpadapter "github.com/TheThingsNetwork/ttn/core/adapters/http"
 	. "github.com/TheThingsNetwork/ttn/core/errors"
 	"github.com/TheThingsNetwork/ttn/utils/errors"
+	"github.com/TheThingsNetwork/ttn/utils/stats"
 	"github.com/apex/log"
 )
 
@@ -56,6 +57,9 @@ func (a *Adapter) Send(p core.Packet, r ...core.Recipient) (core.Packet, error) 
 // broadcast is merely a send where recipients are the predefined list used at instantiation time.
 // Beside, a registration request will be triggered if one of the recipient reponses positively.
 func (a *Adapter) broadcast(p core.Packet) (core.Packet, error) {
+	stats.MarkMeter("http_adapter.broadcast")
+	stats.UpdateHistogram("http_adapter.broadcast_recipients", int64(len(a.recipients)))
+
 	// Generate payload from core packet
 	m, err := json.Marshal(p.Metadata)
 	if err != nil {

--- a/core/adapters/http/broadcast/broadcast.go
+++ b/core/adapters/http/broadcast/broadcast.go
@@ -136,7 +136,9 @@ func (a *Adapter) broadcast(p core.Packet) (core.Packet, error) {
 	}
 
 	// Wait for each request to be done, and return
+	stats.IncCounter("http_adapter.waiting_for_broadcast")
 	wg.Wait()
+	stats.DecCounter("http_adapter.waiting_for_broadcast")
 	close(cherr)
 	close(register)
 	var errs []error

--- a/core/adapters/http/statuspage/statuspage.go
+++ b/core/adapters/http/statuspage/statuspage.go
@@ -57,6 +57,10 @@ func (a *Adapter) handleStatus(w http.ResponseWriter, req *http.Request) {
 	metrics.Each(func(name string, i interface{}) {
 		switch metric := i.(type) {
 
+		case metrics.Counter:
+			m := metric.Snapshot()
+			allStats[name] = m.Count()
+
 		case metrics.Histogram:
 			h := metric.Snapshot()
 			ps := h.Percentiles([]float64{0.25, 0.5, 0.75})

--- a/core/adapters/http/statuspage/statuspage.go
+++ b/core/adapters/http/statuspage/statuspage.go
@@ -1,0 +1,110 @@
+// Copyright © 2015 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+// Package statuspage extends the basic http to show statistics on GET /status
+//
+// The adapter registers a new endpoint [/status/] to an original basic http adapter and serves statistics on it.
+package statuspage
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	httpadapter "github.com/TheThingsNetwork/ttn/core/adapters/http"
+	"github.com/apex/log"
+	"github.com/rcrowley/go-metrics"
+)
+
+// Adapter extending the default http adapter
+type Adapter struct {
+	*httpadapter.Adapter               // The original http adapter
+	ctx                  log.Interface // Logging context
+}
+
+// NewAdapter constructs a new http adapter that also handles status requests
+func NewAdapter(adapter *httpadapter.Adapter, ctx log.Interface) (*Adapter, error) {
+	a := &Adapter{
+		Adapter: adapter,
+		ctx:     ctx,
+	}
+
+	a.RegisterEndpoint("/status/", a.handleStatus)
+
+	return a, nil
+}
+
+// handle request [GET] on /status
+func (a *Adapter) handleStatus(w http.ResponseWriter, req *http.Request) {
+	ctx := a.ctx.WithField("sender", req.RemoteAddr)
+	ctx.Debug("Receiving new status request")
+
+	// Check the http method
+	if req.Method != "GET" {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		w.Write([]byte("Unreckognized HTTP method. Please use [GET] to get the status"))
+		return
+	}
+
+	if strings.Split(req.RemoteAddr, ":")[0] != "127.0.0.1" {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte("Status is only available from the local host"))
+		return
+	}
+
+	allStats := statData{}
+
+	metrics.Each(func(name string, i interface{}) {
+		switch metric := i.(type) {
+
+		case metrics.Histogram:
+			h := metric.Snapshot()
+			ps := h.Percentiles([]float64{0.25, 0.5, 0.75})
+
+			allStats[name] = histData{
+				Avg: h.Mean(),
+				Min: h.Min(),
+				Max: h.Max(),
+				P25: ps[0],
+				P50: ps[1],
+				P75: ps[2],
+			}
+
+		case metrics.Meter:
+			m := metric.Snapshot()
+			allStats[name] = meterData{
+				Rate1:  m.Rate1(),
+				Rate5:  m.Rate5(),
+				Rate15: m.Rate15(),
+				Count:  m.Count(),
+			}
+		}
+	})
+
+	response, err := json.Marshal(allStats)
+	if err != nil {
+		panic(err)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(response)
+}
+
+type statData map[string]interface{}
+
+type meterData struct {
+	Rate1  float64 `json:"rate_1"`
+	Rate5  float64 `json:"rate_5"`
+	Rate15 float64 `json:"rate_15"`
+	Count  int64   `json:"count"`
+}
+
+type histData struct {
+	Avg float64 `json:"avg"`
+	Min int64   `json:"min"`
+	Max int64   `json:"max"`
+	P25 float64 `json:"p_25"`
+	P50 float64 `json:"p_50"`
+	P75 float64 `json:"p_75"`
+}

--- a/core/adapters/semtech/adapter.go
+++ b/core/adapters/semtech/adapter.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/TheThingsNetwork/ttn/core/errors"
 	"github.com/TheThingsNetwork/ttn/semtech"
 	"github.com/TheThingsNetwork/ttn/utils/errors"
+	"github.com/TheThingsNetwork/ttn/utils/stats"
 	"github.com/apex/log"
 )
 
@@ -103,6 +104,7 @@ func (a *Adapter) listen(conn *net.UDPConn) {
 
 		switch pkt.Identifier {
 		case semtech.PULL_DATA: // PULL_DATA -> Respond to the recipient with an ACK
+			stats.MarkMeter("semtech_adapter.pull_data")
 			pullAck, err := semtech.Packet{
 				Version:    semtech.VERSION,
 				Token:      pkt.Token,
@@ -115,6 +117,7 @@ func (a *Adapter) listen(conn *net.UDPConn) {
 			a.ctx.WithField("recipient", addr).Debug("Sending PULL_ACK")
 			a.conn <- udpMsg{addr: addr, raw: pullAck}
 		case semtech.PUSH_DATA: // PUSH_DATA -> Transfer all RXPK to the component
+			stats.MarkMeter("semtech_adapter.push_data")
 			pushAck, err := semtech.Packet{
 				Version:    semtech.VERSION,
 				Token:      pkt.Token,

--- a/core/components/broker.go
+++ b/core/components/broker.go
@@ -7,6 +7,7 @@ import (
 	"github.com/TheThingsNetwork/ttn/core"
 	. "github.com/TheThingsNetwork/ttn/core/errors"
 	"github.com/TheThingsNetwork/ttn/utils/errors"
+	"github.com/TheThingsNetwork/ttn/utils/stats"
 	"github.com/apex/log"
 	"github.com/brocaar/lorawan"
 )
@@ -27,10 +28,13 @@ func NewBroker(db BrokerStorage, ctx log.Interface) *Broker {
 
 // HandleUp implements the core.Component interface
 func (b *Broker) HandleUp(p core.Packet, an core.AckNacker, adapter core.Adapter) error {
-	b.ctx.Debug("Handle uplink packet")
+	stats.MarkMeter("broker.uplink.in")
+	b.ctx.Debug("Handling uplink packet")
+
 	// 1. Lookup for entries for the associated device
 	devAddr, err := p.DevAddr()
 	if err != nil {
+		stats.MarkMeter("broker.uplink.invalid")
 		b.ctx.Warn("Uplink Invalid")
 		an.Nack()
 		return errors.New(ErrInvalidStructure, err)
@@ -40,13 +44,16 @@ func (b *Broker) HandleUp(p core.Packet, an core.AckNacker, adapter core.Adapter
 	if err != nil {
 		switch err.(errors.Failure).Nature {
 		case ErrWrongBehavior:
+			stats.MarkMeter("broker.uplink.device_not_registered")
 			ctx.Warn("Uplink device not found")
 			return an.Nack()
 		default:
+			b.ctx.Warn("Database lookup failed")
 			an.Nack()
 			return errors.New(ErrFailedOperation, err)
 		}
 	}
+	stats.UpdateHistogram("broker.handlers_per_dev_addr", int64(len(entries)))
 
 	// 2. Several handler might be associated to the same device, we distinguish them using MIC
 	// check. Only one should verify the MIC check.
@@ -61,11 +68,13 @@ func (b *Broker) HandleUp(p core.Packet, an core.AckNacker, adapter core.Adapter
 				Id:      entry.Id,
 				Address: entry.Url,
 			}
+			stats.MarkMeter("broker.uplink.match_handler")
 			ctx.WithField("handler", handler).Debug("Associated device with handler")
 			break
 		}
 	}
 	if handler == nil {
+		stats.MarkMeter("broker.uplink.no_match_handler")
 		ctx.Warn("Could not find handler for device")
 		return an.Nack()
 	}
@@ -73,9 +82,12 @@ func (b *Broker) HandleUp(p core.Packet, an core.AckNacker, adapter core.Adapter
 	// 3. If one was found, we forward the packet and wait for the response
 	response, err := adapter.Send(p, *handler)
 	if err != nil {
+		stats.MarkMeter("broker.uplink.bad_handler_response")
 		an.Nack()
 		return errors.New(ErrFailedOperation, err)
 	}
+
+	stats.MarkMeter("broker.uplink.ok")
 	return an.Ack(&response)
 }
 
@@ -86,6 +98,9 @@ func (b *Broker) HandleDown(p core.Packet, an core.AckNacker, a core.Adapter) er
 
 // Register implements the core.Component interface
 func (b *Broker) Register(r core.Registration, an core.AckNacker) error {
+	stats.MarkMeter("broker.registration.in")
+	b.ctx.Debug("Handling registration")
+
 	id, okId := r.Recipient.Id.(string)
 	url, okUrl := r.Recipient.Address.(string)
 	nwkSKey, okNwkSKey := r.Options.(lorawan.AES128Key)
@@ -93,6 +108,7 @@ func (b *Broker) Register(r core.Registration, an core.AckNacker) error {
 	ctx := b.ctx.WithField("devAddr", r.DevAddr)
 
 	if !(okId && okUrl && okNwkSKey) {
+		stats.MarkMeter("broker.registration.invalid")
 		ctx.Warn("Invalid Registration")
 		an.Nack()
 		return errors.New(ErrInvalidStructure, "Invalid registration params")
@@ -100,11 +116,13 @@ func (b *Broker) Register(r core.Registration, an core.AckNacker) error {
 
 	entry := brokerEntry{Id: id, Url: url, NwkSKey: nwkSKey}
 	if err := b.db.Store(r.DevAddr, entry); err != nil {
+		stats.MarkMeter("broker.registration.failed")
 		ctx.WithError(err).Error("Failed Registration")
 		an.Nack()
 		return errors.New(ErrFailedOperation, err)
 	}
 
+	stats.MarkMeter("broker.registration.ok")
 	ctx.Debug("Successful Registration")
 	return an.Ack(nil)
 }

--- a/integration/broker/main.go
+++ b/integration/broker/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/TheThingsNetwork/ttn/core/adapters/http"
 	"github.com/TheThingsNetwork/ttn/core/adapters/http/parser"
 	"github.com/TheThingsNetwork/ttn/core/adapters/http/pubsub"
+	"github.com/TheThingsNetwork/ttn/core/adapters/http/statuspage"
 	"github.com/TheThingsNetwork/ttn/core/components"
 	"github.com/apex/log"
 	"github.com/apex/log/handlers/text"
@@ -37,6 +38,11 @@ func main() {
 	hdlHTTPAdapter, err := http.NewAdapter(uint(handlersPort), parser.JSON{}, ctx.WithField("tag", "Handlers Adapter"))
 	if err != nil {
 		ctx.WithError(err).Fatal("Could not start Handlers Adapter")
+	}
+
+	_, err = statuspage.NewAdapter(hdlHTTPAdapter, ctx.WithField("tag", "Broker Adapter"))
+	if err != nil {
+		ctx.WithError(err).Fatal("Could not start Broker Adapter")
 	}
 
 	hdlAdapter, err := pubsub.NewAdapter(hdlHTTPAdapter, parser.PubSub{}, ctx.WithField("tag", "Handlers Adapter"))

--- a/integration/router/main.go
+++ b/integration/router/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/TheThingsNetwork/ttn/core/adapters/http"
 	"github.com/TheThingsNetwork/ttn/core/adapters/http/broadcast"
 	"github.com/TheThingsNetwork/ttn/core/adapters/http/parser"
+	"github.com/TheThingsNetwork/ttn/core/adapters/http/statuspage"
 	"github.com/TheThingsNetwork/ttn/core/adapters/semtech"
 	"github.com/TheThingsNetwork/ttn/core/components"
 	"github.com/apex/log"
@@ -38,6 +39,11 @@ func main() {
 	}
 
 	pktAdapter, err := http.NewAdapter(uint(tcpPort), parser.JSON{}, ctx.WithField("tag", "Broker Adapter"))
+	if err != nil {
+		ctx.WithError(err).Fatal("Could not start Broker Adapter")
+	}
+
+	_, err = statuspage.NewAdapter(pktAdapter, ctx.WithField("tag", "Broker Adapter"))
 	if err != nil {
 		ctx.WithError(err).Fatal("Could not start Broker Adapter")
 	}

--- a/utils/stats/stats.go
+++ b/utils/stats/stats.go
@@ -11,3 +11,11 @@ func MarkMeter(name string) {
 func UpdateHistogram(name string, value int64) {
 	metrics.GetOrRegisterHistogram(name, metrics.DefaultRegistry, metrics.NewUniformSample(1000)).Update(value)
 }
+
+func IncCounter(name string) {
+	metrics.GetOrRegisterCounter(name, metrics.DefaultRegistry).Inc(1)
+}
+
+func DecCounter(name string) {
+	metrics.GetOrRegisterCounter(name, metrics.DefaultRegistry).Dec(1)
+}

--- a/utils/stats/stats.go
+++ b/utils/stats/stats.go
@@ -1,0 +1,13 @@
+package stats
+
+import "github.com/rcrowley/go-metrics"
+
+// MarkMeter registers an event
+func MarkMeter(name string) {
+	metrics.GetOrRegisterMeter(name, metrics.DefaultRegistry).Mark(1)
+}
+
+// UpdateHistogram registers a new value for a histogram
+func UpdateHistogram(name string, value int64) {
+	metrics.GetOrRegisterHistogram(name, metrics.DefaultRegistry, metrics.NewUniformSample(1000)).Update(value)
+}

--- a/utils/stats/stats.go
+++ b/utils/stats/stats.go
@@ -1,3 +1,7 @@
+// Copyright © 2015 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+// Package stats supports the collection of metrics from a running component.
 package stats
 
 import "github.com/rcrowley/go-metrics"
@@ -12,10 +16,12 @@ func UpdateHistogram(name string, value int64) {
 	metrics.GetOrRegisterHistogram(name, metrics.DefaultRegistry, metrics.NewUniformSample(1000)).Update(value)
 }
 
+// IncCounter increments a counter by 1
 func IncCounter(name string) {
 	metrics.GetOrRegisterCounter(name, metrics.DefaultRegistry).Inc(1)
 }
 
+// DecCounter decrements a counter by 1
 func DecCounter(name string) {
 	metrics.GetOrRegisterCounter(name, metrics.DefaultRegistry).Dec(1)
 }


### PR DESCRIPTION
This PR adds support for collecting live metrics from components.

## Collection

```go
import "github.com/TheThingsNetwork/ttn/utils/stats"

//Register an event. This will output an event count and 1/5/15 minute rates (events/second) on the status page.
stats.MarkMeter("incoming_request")

//Add a number to a histogram. This will output min/avg/max values and .25/.50/.75 percentiles on the status page.
stats.UpdateHistogram("lookup_results", numResults)

//Increment or Decrement a counter
stats.IncCounter("connected_clients")
stats.DecCounter("connected_clients")
```

## Status Page

The Router will respond to `[GET] localhost:<tcp-port>/status/`
The Broker will respond to `[GET] localhost:<handlers-port>/status/`

This PR closes #25.