### PR TITLE
Login functionality for ttnctl

### DIFF
--- a/ttnctl/cmd/users.go
+++ b/ttnctl/cmd/users.go
@@ -4,29 +4,50 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
+	"github.com/TheThingsNetwork/ttn/ttnctl/util"
 	"github.com/howeyc/gopass"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
+type token struct {
+	AccessToken      string `json:"access_token"`
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
 // usersCmd represents the users command
 var usersCmd = &cobra.Command{
-	Use:   "users",
-	Short: "Manage users on the account server",
-	Long:  `ttnctl users allows you to manage users`,
+	Use:   "user",
+	Short: "Show the current user",
+	Long:  `ttnctl user shows the current logged on user`,
 	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Help()
+		t, err := util.LoadAuth(viper.GetString("ttn-account-server"))
+		if err != nil {
+			ctx.WithError(err).Fatal("Failed to load authentication")
+		}
+
+		if t == nil {
+			ctx.Warn("No login found")
+			return
+		}
+
+		// TODO: Validate token
+
+		ctx.Infof("Logged on as %s", t.Email)
 	},
 }
 
 var usersCreateCmd = &cobra.Command{
 	Use:   "create [e-mail]",
 	Short: "Create a new user",
-	Long:  `ttnctl users create allows you to create a new user`,
+	Long:  `ttnctl user create allows you to create a new user`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
 			ctx.Fatal("Insufficient arguments")
@@ -39,7 +60,7 @@ var usersCreateCmd = &cobra.Command{
 			ctx.Fatal("Invalid password")
 		}
 
-		uri := fmt.Sprintf("http://%s/register", viper.GetString("ttn-account-server"))
+		uri := fmt.Sprintf("%s/register", viper.GetString("ttn-account-server"))
 		values := url.Values{
 			"email":    {email},
 			"password": {string(password)},
@@ -58,10 +79,70 @@ var usersCreateCmd = &cobra.Command{
 	},
 }
 
+var usersLoginCmd = &cobra.Command{
+	Use:   "login [e-mail]",
+	Short: "Login",
+	Long:  `ttnctl user login allows you to login`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) < 1 {
+			ctx.Fatal("Insufficient arguments")
+		}
+
+		email := args[0]
+		fmt.Print("Password: ")
+		password, err := gopass.GetPasswd()
+		if err != nil {
+			ctx.Fatal("Invalid password")
+		}
+
+		server := viper.GetString("ttn-account-server")
+		uri := fmt.Sprintf("%s/token", server)
+		values := url.Values{
+			"grant_type": {"password"},
+			"username":   {email},
+			"password":   {string(password)},
+		}
+		req, err := http.NewRequest("POST", uri, strings.NewReader(values.Encode()))
+		if err != nil {
+			ctx.WithError(err).Fatal("Create request failed")
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.SetBasicAuth("ttnctl", "")
+
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			ctx.WithError(err).Fatal("Request failed")
+		}
+		defer resp.Body.Close()
+
+		decoder := json.NewDecoder(resp.Body)
+		var t token
+		if err := decoder.Decode(&t); err != nil {
+			ctx.WithError(err).Fatal("Failed to parse response")
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			if t.Error != "" {
+				ctx.Fatalf("Request failed: %s", t.ErrorDescription)
+			} else {
+				ctx.Fatalf("Request failed: %s", resp.Status)
+			}
+		}
+
+		ctx.Infof("Logged in as %s", email)
+
+		if err := util.SaveAuth(server, email, t.AccessToken); err != nil {
+			ctx.WithError(err).Error("Failed to save login")
+		}
+	},
+}
+
 func init() {
 	RootCmd.AddCommand(usersCmd)
 	usersCmd.AddCommand(usersCreateCmd)
+	usersCmd.AddCommand(usersLoginCmd)
 
-	usersCmd.PersistentFlags().String("ttn-account-server", "account.thethings.network", "The Things Network OAuth 2.0 account server")
+	usersCmd.PersistentFlags().String("ttn-account-server", "https://account.thethings.network", "The Things Network OAuth 2.0 account server")
 	viper.BindPFlag("ttn-account-server", usersCmd.PersistentFlags().Lookup("ttn-account-server"))
 }

--- a/ttnctl/cmd/users.go
+++ b/ttnctl/cmd/users.go
@@ -1,0 +1,67 @@
+// Copyright © 2016 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/howeyc/gopass"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// usersCmd represents the users command
+var usersCmd = &cobra.Command{
+	Use:   "users",
+	Short: "Manage users on the account server",
+	Long:  `ttnctl users allows you to manage users`,
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+var usersCreateCmd = &cobra.Command{
+	Use:   "create [e-mail]",
+	Short: "Create a new user",
+	Long:  `ttnctl users create allows you to create a new user`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) < 1 {
+			ctx.Fatal("Insufficient arguments")
+		}
+
+		email := args[0]
+		fmt.Print("Password: ")
+		password, err := gopass.GetPasswd()
+		if err != nil {
+			ctx.Fatal("Invalid password")
+		}
+
+		uri := fmt.Sprintf("http://%s/register", viper.GetString("ttn-account-server"))
+		values := url.Values{
+			"email":    {email},
+			"password": {string(password)},
+		}
+		res, err := http.PostForm(uri, values)
+		if err != nil {
+			ctx.WithError(err).Fatal("Registration failed")
+		}
+		defer res.Body.Close()
+
+		if res.StatusCode != http.StatusCreated {
+			ctx.Fatalf("Registration failed: %d %s", res.StatusCode, res.Status)
+		}
+
+		ctx.Info("User created")
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(usersCmd)
+	usersCmd.AddCommand(usersCreateCmd)
+
+	usersCmd.PersistentFlags().String("ttn-account-server", "account.thethings.network", "The Things Network OAuth 2.0 account server")
+	viper.BindPFlag("ttn-account-server", usersCmd.PersistentFlags().Lookup("ttn-account-server"))
+}

--- a/ttnctl/util/auth.go
+++ b/ttnctl/util/auth.go
@@ -1,0 +1,97 @@
+// Copyright © 2016 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package util
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path"
+)
+
+const (
+	authsFileName = ".ttnctl/auths.json"
+	authsFilePerm = 0600
+)
+
+// Auth represents an authentication token
+type Auth struct {
+	Token string `json:"token"`
+	Email string `json:"email"`
+}
+
+type auths struct {
+	Auths map[string]*Auth `json:"auths"`
+}
+
+// LoadAuth loads the authentication token for the specified server
+func LoadAuth(server string) (*Auth, error) {
+	a, err := loadAuths()
+	if err != nil {
+		return nil, err
+	}
+	return a.Auths[server], nil
+}
+
+// SaveAuth saves the authentication token for the specified server and e-mail
+func SaveAuth(server, email, token string) error {
+	a, err := loadAuths()
+	// Ignore error - just create new structure
+	if err != nil || a == nil {
+		a = &auths{}
+	}
+
+	// Initialize the map if not exists and add the token
+	if a.Auths == nil {
+		a.Auths = make(map[string]*Auth)
+	}
+	a.Auths[server] = &Auth{token, email}
+
+	// Marshal and write to disk
+	buff, err := json.Marshal(&a)
+	if err != nil {
+		return err
+	}
+	filename, err := getAuthsFilename()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(path.Dir(filename), 0755); err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(filename, buff, authsFilePerm); err != nil {
+		return err
+	}
+	return nil
+}
+
+// loadAuths loads the authentication tokens. This function always returns an
+// empty structure if the file does not exist.
+func loadAuths() (*auths, error) {
+	filename, err := getAuthsFilename()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := os.Stat(filename); os.IsNotExist(err) {
+		return &auths{}, nil
+	}
+	buff, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	var a auths
+	if err := json.Unmarshal(buff, &a); err != nil {
+		return nil, err
+	}
+	return &a, nil
+}
+
+func getAuthsFilename() (string, error) {
+	u, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+	return path.Join(u.HomeDir, authsFileName), nil
+}


### PR DESCRIPTION
Command `ttnctl user login [e-mail]` allows you to login. Tokens are persisted in `$HOME/.ttnctl/auths.json` and are available through `LoadAuth()` in the `utils` package