### PR TITLE
Token validation in Broker

### DIFF
--- a/core/components/broker/broker.go
+++ b/core/components/broker/broker.go
@@ -18,7 +18,7 @@ import (
 // component implements the core.BrokerServer interface
 type component struct {
 	Components
-	SecretKey    [32]byte
+	TokenKey     []byte
 	NetAddrUp    string
 	NetAddrDown  string
 	MaxDevNonces uint
@@ -35,7 +35,7 @@ type Components struct {
 type Options struct {
 	NetAddrUp   string
 	NetAddrDown string
-	SecretKey   [32]byte
+	TokenKey    []byte
 }
 
 // Interface defines the Broker interface
@@ -52,7 +52,7 @@ func New(c Components, o Options) Interface {
 		NetAddrUp:    o.NetAddrUp,
 		NetAddrDown:  o.NetAddrDown,
 		MaxDevNonces: 10,
-		SecretKey:    [32]byte{14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 42, 42, 42, 42, 42, 42}, // TODO Use options & ENV var
+		TokenKey:     o.TokenKey,
 	}
 }
 

--- a/core/components/broker/brokerManager.go
+++ b/core/components/broker/brokerManager.go
@@ -101,13 +101,28 @@ func (b component) UpsertABP(bctx context.Context, req *core.UpsertABPBrokerReq)
 // validateToken verify an OAuth Bearer token pass through metadata during RPC
 func (b component) validateToken(ctx context.Context, token string, appEUI []byte) error {
 	parsed, err := jwt.Parse(token, func(token *jwt.Token) (interface{}, error) {
-		return b.SecretKey[:], nil
+		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
+			return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
+		}
+		return b.TokenKey, nil
 	})
 	if err != nil {
 		return errors.New(errors.Structural, "Unable to parse token")
 	}
-	if !parsed.Valid || parsed.Claims["sub"] != fmt.Sprintf("%X", appEUI) {
-		return errors.New(errors.Structural, "Invalid token.")
+	if !parsed.Valid {
+		return errors.New(errors.Operational, "The token is not valid or is expired.")
 	}
-	return nil
+
+	apps, ok := parsed.Claims["apps"].([]interface{})
+	if !ok {
+		return fmt.Errorf("Invalid type of apps claim: %T", parsed.Claims["apps"])
+	}
+
+	for _, a := range apps {
+		if s, ok := a.(string); ok && s == fmt.Sprintf("%X", appEUI) {
+			return nil
+		}
+	}
+
+	return errors.New(errors.Operational, "Unauthorized")
 }

--- a/ttnctl/AUTHORS
+++ b/ttnctl/AUTHORS
@@ -9,3 +9,4 @@
 # Please keep the list sorted.
 
 Hylke Visser <htdvisser@gmail.com>
+Johan Stokking <johan@thethingsnetwork.org>

--- a/ttnctl/cmd/applications.go
+++ b/ttnctl/cmd/applications.go
@@ -73,9 +73,14 @@ var applicationsCreateCmd = &cobra.Command{
 			return
 		}
 
+		appEUI, err := util.Parse64(args[0])
+		if err != nil {
+			ctx.Fatalf("Invalid AppEUI: %s", err)
+		}
+
 		server := viper.GetString("ttn-account-server")
 		values := url.Values{
-			"eui":  {args[0]},
+			"eui":  {fmt.Sprintf("%X", appEUI)},
 			"name": {args[1]},
 		}
 		req, err := util.NewRequestWithAuth(server, "POST", fmt.Sprintf("%s/applications", server), strings.NewReader(values.Encode()))

--- a/ttnctl/cmd/applications.go
+++ b/ttnctl/cmd/applications.go
@@ -4,12 +4,21 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/TheThingsNetwork/ttn/ttnctl/util"
+	"github.com/gosuri/uitable"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
+
+type app struct {
+	EUI   string `json:"eui"`
+	Name  string `json:"name"`
+	Owner string `json:"owner"`
+}
 
 // applicationsCmd represents the applications command
 var applicationsCmd = &cobra.Command{
@@ -18,10 +27,36 @@ var applicationsCmd = &cobra.Command{
 	Long:  `ttnctl applications retrieves the applications of the logged on user.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		server := viper.GetString("ttn-account-server")
-		_, err := util.NewRequestWithAuth(server, "GET", fmt.Sprintf("%s/applications", server), nil)
+		req, err := util.NewRequestWithAuth(server, "GET", fmt.Sprintf("%s/applications", server), nil)
 		if err != nil {
-			ctx.WithError(err).Fatal("Create request failed")
+			ctx.WithError(err).Fatal("Failed to created authenticated request")
 		}
+
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			ctx.WithError(err).Fatal("Failed to get applications")
+		}
+		if resp.StatusCode != http.StatusOK {
+			ctx.Fatalf("Failed to get applications: %s", resp.Status)
+		}
+
+		defer resp.Body.Close()
+		decoder := json.NewDecoder(resp.Body)
+		var apps []*app
+		err = decoder.Decode(&apps)
+		if err != nil {
+			ctx.WithError(err).Fatal("Failed to read applications")
+		}
+
+		ctx.Infof("Found %d application(s)", len(apps))
+		table := uitable.New()
+		table.MaxColWidth = 70
+		table.AddRow("EUI", "Name", "Owner")
+		for _, app := range apps {
+			table.AddRow(app.EUI, app.Name, app.Owner)
+		}
+		fmt.Println(table)
 	},
 }
 

--- a/ttnctl/cmd/applications.go
+++ b/ttnctl/cmd/applications.go
@@ -1,0 +1,25 @@
+// Copyright © 2016 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// applicationsCmd represents the applications command
+var applicationsCmd = &cobra.Command{
+	Use:   "applications",
+	Short: "Show applications",
+	Long:  `ttnctl applications retrieves your applications of the logged on user.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// TODO: Work your own magic here
+		fmt.Println("applications called")
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(applicationsCmd)
+}

--- a/ttnctl/cmd/applications.go
+++ b/ttnctl/cmd/applications.go
@@ -4,19 +4,25 @@
 package cmd
 
 import (
-	"fmt"
-
+	"github.com/TheThingsNetwork/ttn/ttnctl/util"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // applicationsCmd represents the applications command
 var applicationsCmd = &cobra.Command{
 	Use:   "applications",
 	Short: "Show applications",
-	Long:  `ttnctl applications retrieves your applications of the logged on user.`,
+	Long:  `ttnctl applications retrieves the applications of the logged on user.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// TODO: Work your own magic here
-		fmt.Println("applications called")
+		auth, err := util.LoadAuth(viper.GetString("ttn-account-server"))
+		if err != nil {
+			ctx.WithError(err).Fatal("Failed to load authentication")
+		}
+		if auth == nil {
+			ctx.Fatal("No authentication found. Please login")
+		}
+
 	},
 }
 

--- a/ttnctl/cmd/applications.go
+++ b/ttnctl/cmd/applications.go
@@ -4,6 +4,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/TheThingsNetwork/ttn/ttnctl/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -15,14 +17,11 @@ var applicationsCmd = &cobra.Command{
 	Short: "Show applications",
 	Long:  `ttnctl applications retrieves the applications of the logged on user.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		auth, err := util.LoadAuth(viper.GetString("ttn-account-server"))
+		server := viper.GetString("ttn-account-server")
+		_, err := util.NewRequestWithAuth(server, "GET", fmt.Sprintf("%s/applications", server), nil)
 		if err != nil {
-			ctx.WithError(err).Fatal("Failed to load authentication")
+			ctx.WithError(err).Fatal("Create request failed")
 		}
-		if auth == nil {
-			ctx.Fatal("No authentication found. Please login")
-		}
-
 	},
 }
 

--- a/ttnctl/cmd/device.go
+++ b/ttnctl/cmd/device.go
@@ -88,7 +88,8 @@ var devicesRegisterCmd = &cobra.Command{
 	Long:  `ttnctl devices register creates or updates an OTAA registration on the Handler`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 2 {
-			ctx.Fatal("Insufficient arguments")
+			cmd.Help()
+			return
 		}
 
 		appEUI, err := util.Parse64(viper.GetString("app-eui"))
@@ -135,7 +136,8 @@ var devicesRegisterPersonalizedCmd = &cobra.Command{
 	Long:  `ttnctl devices register creates or updates an ABP registration on the Handler`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 3 {
-			ctx.Fatal("Insufficient arguments")
+			cmd.Help()
+			return
 		}
 
 		appEUI, err := util.Parse64(viper.GetString("app-eui"))

--- a/ttnctl/cmd/device.go
+++ b/ttnctl/cmd/device.go
@@ -46,7 +46,7 @@ var devicesCmd = &cobra.Command{
 
 		manager := getHandlerManager()
 		res, err := manager.ListDevices(context.Background(), &core.ListDevicesHandlerReq{
-			Token:  auth.Token,
+			Token:  auth.AccessToken,
 			AppEUI: appEUI,
 		})
 		if err != nil {
@@ -116,7 +116,7 @@ var devicesRegisterCmd = &cobra.Command{
 
 		manager := getHandlerManager()
 		res, err := manager.UpsertOTAA(context.Background(), &core.UpsertOTAAHandlerReq{
-			Token:  auth.Token,
+			Token:  auth.AccessToken,
 			AppEUI: appEUI,
 			DevEUI: devEUI,
 			AppKey: appKey,
@@ -168,7 +168,7 @@ var devicesRegisterPersonalizedCmd = &cobra.Command{
 
 		manager := getHandlerManager()
 		res, err := manager.UpsertABP(context.Background(), &core.UpsertABPHandlerReq{
-			Token:   auth.Token,
+			Token:   auth.AccessToken,
 			AppEUI:  appEUI,
 			DevAddr: devAddr,
 			AppSKey: appSKey,

--- a/ttnctl/cmd/device.go
+++ b/ttnctl/cmd/device.go
@@ -36,10 +36,17 @@ var devicesCmd = &cobra.Command{
 			ctx.Fatalf("Invalid AppEUI: %s", err)
 		}
 
-		manager := getHandlerManager()
+		auth, err := util.LoadAuth(viper.GetString("ttn-account-server"))
+		if err != nil {
+			ctx.WithError(err).Fatal("Failed to load authentication")
+		}
+		if auth == nil {
+			ctx.Fatal("No authentication found. Please login")
+		}
 
+		manager := getHandlerManager()
 		res, err := manager.ListDevices(context.Background(), &core.ListDevicesHandlerReq{
-			Token:  viper.GetString("app-token"),
+			Token:  auth.Token,
 			AppEUI: appEUI,
 		})
 		if err != nil {
@@ -99,9 +106,17 @@ var devicesRegisterCmd = &cobra.Command{
 			ctx.Fatalf("Invalid AppKey: %s", err)
 		}
 
+		auth, err := util.LoadAuth(viper.GetString("ttn-account-server"))
+		if err != nil {
+			ctx.WithError(err).Fatal("Failed to load authentication")
+		}
+		if auth == nil {
+			ctx.Fatal("No authentication found. Please login")
+		}
+
 		manager := getHandlerManager()
 		res, err := manager.UpsertOTAA(context.Background(), &core.UpsertOTAAHandlerReq{
-			Token:  viper.GetString("app-token"),
+			Token:  auth.Token,
 			AppEUI: appEUI,
 			DevEUI: devEUI,
 			AppKey: appKey,
@@ -143,9 +158,17 @@ var devicesRegisterPersonalizedCmd = &cobra.Command{
 			ctx.Fatalf("Invalid AppSKey: %s", err)
 		}
 
+		auth, err := util.LoadAuth(viper.GetString("ttn-account-server"))
+		if err != nil {
+			ctx.WithError(err).Fatal("Failed to load authentication")
+		}
+		if auth == nil {
+			ctx.Fatal("No authentication found. Please login")
+		}
+
 		manager := getHandlerManager()
 		res, err := manager.UpsertABP(context.Background(), &core.UpsertABPHandlerReq{
-			Token:   viper.GetString("app-token"),
+			Token:   auth.Token,
 			AppEUI:  appEUI,
 			DevAddr: devAddr,
 			AppSKey: appSKey,

--- a/ttnctl/cmd/root.go
+++ b/ttnctl/cmd/root.go
@@ -63,7 +63,7 @@ func init() {
 	RootCmd.PersistentFlags().String("app-eui", "0102030405060708", "The app EUI to use")
 	viper.BindPFlag("app-eui", RootCmd.PersistentFlags().Lookup("app-eui"))
 
-	RootCmd.PersistentFlags().String("ttn-account-server", "https://account.thethings.network", "The address of the OAuth 2.0 server")
+	RootCmd.PersistentFlags().String("ttn-account-server", "https://account.thethingsnetwork.org", "The address of the OAuth 2.0 server")
 	viper.BindPFlag("ttn-account-server", RootCmd.PersistentFlags().Lookup("ttn-account-server"))
 }
 

--- a/ttnctl/cmd/root.go
+++ b/ttnctl/cmd/root.go
@@ -63,9 +63,8 @@ func init() {
 	RootCmd.PersistentFlags().String("app-eui", "0102030405060708", "The app EUI to use")
 	viper.BindPFlag("app-eui", RootCmd.PersistentFlags().Lookup("app-eui"))
 
-	RootCmd.PersistentFlags().String("app-token", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJUVE4tSEFORExFUi0xIiwiaXNzIjoiVGhlVGhpbmdzVGhlTmV0d29yayIsInN1YiI6IjAxMDIwMzA0MDUwNjA3MDgifQ.zMHNXAVgQj672lwwDVmfYshpMvPwm6A8oNWJ7teGS2A", "The app Token to use")
-	viper.BindPFlag("app-token", RootCmd.PersistentFlags().Lookup("app-token"))
-
+	RootCmd.PersistentFlags().String("ttn-account-server", "https://account.thethings.network", "The address of the OAuth 2.0 server")
+	viper.BindPFlag("ttn-account-server", RootCmd.PersistentFlags().Lookup("ttn-account-server"))
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/ttnctl/cmd/user.go
+++ b/ttnctl/cmd/user.go
@@ -39,7 +39,8 @@ var userCreateCmd = &cobra.Command{
 	Long:  `ttnctl user create allows you to create a new user`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
-			ctx.Fatal("Insufficient arguments")
+			cmd.Help()
+			return
 		}
 
 		email := args[0]
@@ -73,7 +74,8 @@ var userLoginCmd = &cobra.Command{
 	Long:  `ttnctl user login allows you to login`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
-			ctx.Fatal("Insufficient arguments")
+			cmd.Help()
+			return
 		}
 
 		email := args[0]

--- a/ttnctl/cmd/user.go
+++ b/ttnctl/cmd/user.go
@@ -30,8 +30,6 @@ var userCmd = &cobra.Command{
 			return
 		}
 
-		// TODO: Validate token online
-
 		ctx.Infof("Logged on as %s", t.Email)
 	},
 }

--- a/ttnctl/cmd/user.go
+++ b/ttnctl/cmd/user.go
@@ -26,7 +26,7 @@ var userCmd = &cobra.Command{
 		}
 
 		if t == nil {
-			ctx.Warn("No login found or token expired")
+			ctx.Warn("No login found. Please login with ttnctl user login [e-mail]")
 			return
 		}
 
@@ -93,8 +93,22 @@ var userLoginCmd = &cobra.Command{
 	},
 }
 
+var userLogoutCmd = &cobra.Command{
+	Use:   "logout",
+	Short: "Logout the current user",
+	Long:  `ttnctl user logout logs out the current user`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := util.Logout(viper.GetString("ttn-account-server")); err != nil {
+			ctx.WithError(err).Fatal("Failed to log out")
+		}
+
+		ctx.Info("Logged out")
+	},
+}
+
 func init() {
 	RootCmd.AddCommand(userCmd)
 	userCmd.AddCommand(userCreateCmd)
 	userCmd.AddCommand(userLoginCmd)
+	userCmd.AddCommand(userLogoutCmd)
 }

--- a/ttnctl/cmd/user.go
+++ b/ttnctl/cmd/user.go
@@ -24,7 +24,6 @@ var userCmd = &cobra.Command{
 		if err != nil {
 			ctx.WithError(err).Fatal("Failed to load authentication token")
 		}
-
 		if t == nil {
 			ctx.Warn("No login found. Please login with ttnctl user login [e-mail]")
 			return

--- a/ttnctl/cmd/users.go
+++ b/ttnctl/cmd/users.go
@@ -142,7 +142,4 @@ func init() {
 	RootCmd.AddCommand(usersCmd)
 	usersCmd.AddCommand(usersCreateCmd)
 	usersCmd.AddCommand(usersLoginCmd)
-
-	usersCmd.PersistentFlags().String("ttn-account-server", "https://account.thethings.network", "The Things Network OAuth 2.0 account server")
-	viper.BindPFlag("ttn-account-server", usersCmd.PersistentFlags().Lookup("ttn-account-server"))
 }

--- a/ttnctl/cmd/users.go
+++ b/ttnctl/cmd/users.go
@@ -4,29 +4,50 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
+	"github.com/TheThingsNetwork/ttn/ttnctl/util"
 	"github.com/howeyc/gopass"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
+type token struct {
+	AccessToken      string `json:"access_token"`
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
 // usersCmd represents the users command
 var usersCmd = &cobra.Command{
-	Use:   "users",
-	Short: "Manage users on the account server",
-	Long:  `ttnctl users allows you to manage users`,
+	Use:   "user",
+	Short: "Show the current user",
+	Long:  `ttnctl user shows the current logged on user`,
 	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Help()
+		t, err := util.LoadAuth(viper.GetString("ttn-account-server"))
+		if err != nil {
+			ctx.WithError(err).Fatal("Failed to load authentication")
+		}
+
+		if t == nil {
+			ctx.Warn("No login found")
+			return
+		}
+
+		// TODO: Validate token
+
+		ctx.Infof("Logged on as %s", t.Email)
 	},
 }
 
 var usersCreateCmd = &cobra.Command{
 	Use:   "create [e-mail]",
 	Short: "Create a new user",
-	Long:  `ttnctl users create allows you to create a new user`,
+	Long:  `ttnctl user create allows you to create a new user`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
 			ctx.Fatal("Insufficient arguments")
@@ -39,7 +60,7 @@ var usersCreateCmd = &cobra.Command{
 			ctx.Fatal("Invalid password")
 		}
 
-		uri := fmt.Sprintf("http://%s/register", viper.GetString("ttn-account-server"))
+		uri := fmt.Sprintf("%s/register", viper.GetString("ttn-account-server"))
 		values := url.Values{
 			"email":    {email},
 			"password": {string(password)},
@@ -58,10 +79,70 @@ var usersCreateCmd = &cobra.Command{
 	},
 }
 
+var usersLoginCmd = &cobra.Command{
+	Use:   "login [e-mail]",
+	Short: "Login",
+	Long:  `ttnctl user login allows you to login`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) < 1 {
+			ctx.Fatal("Insufficient arguments")
+		}
+
+		email := args[0]
+		fmt.Print("Password: ")
+		password, err := gopass.GetPasswd()
+		if err != nil {
+			ctx.Fatal("Invalid password")
+		}
+
+		server := viper.GetString("ttn-account-server")
+		uri := fmt.Sprintf("%s/token", server)
+		values := url.Values{
+			"grant_type": {"password"},
+			"username":   {email},
+			"password":   {string(password)},
+		}
+		req, err := http.NewRequest("POST", uri, strings.NewReader(values.Encode()))
+		if err != nil {
+			ctx.WithError(err).Fatal("Create request failed")
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.SetBasicAuth("ttnctl", "")
+
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			ctx.WithError(err).Fatal("Request failed")
+		}
+		defer resp.Body.Close()
+
+		decoder := json.NewDecoder(resp.Body)
+		var t token
+		if err := decoder.Decode(&t); err != nil {
+			ctx.WithError(err).Fatal("Failed to parse response")
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			if t.Error != "" {
+				ctx.Fatalf("Request failed: %s", t.ErrorDescription)
+			} else {
+				ctx.Fatalf("Request failed: %s", resp.Status)
+			}
+		}
+
+		ctx.Infof("Logged in as %s", email)
+
+		if err := util.SaveAuth(server, email, t.AccessToken); err != nil {
+			ctx.WithError(err).Error("Failed to save login")
+		}
+	},
+}
+
 func init() {
 	RootCmd.AddCommand(usersCmd)
 	usersCmd.AddCommand(usersCreateCmd)
+	usersCmd.AddCommand(usersLoginCmd)
 
-	usersCmd.PersistentFlags().String("ttn-account-server", "account.thethings.network", "The Things Network OAuth 2.0 account server")
+	usersCmd.PersistentFlags().String("ttn-account-server", "https://account.thethings.network", "The Things Network OAuth 2.0 account server")
 	viper.BindPFlag("ttn-account-server", usersCmd.PersistentFlags().Lookup("ttn-account-server"))
 }

--- a/ttnctl/cmd/users.go
+++ b/ttnctl/cmd/users.go
@@ -1,0 +1,67 @@
+// Copyright © 2016 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/howeyc/gopass"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// usersCmd represents the users command
+var usersCmd = &cobra.Command{
+	Use:   "users",
+	Short: "Manage users on the account server",
+	Long:  `ttnctl users allows you to manage users`,
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+var usersCreateCmd = &cobra.Command{
+	Use:   "create [e-mail]",
+	Short: "Create a new user",
+	Long:  `ttnctl users create allows you to create a new user`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) < 1 {
+			ctx.Fatal("Insufficient arguments")
+		}
+
+		email := args[0]
+		fmt.Print("Password: ")
+		password, err := gopass.GetPasswd()
+		if err != nil {
+			ctx.Fatal("Invalid password")
+		}
+
+		uri := fmt.Sprintf("http://%s/register", viper.GetString("ttn-account-server"))
+		values := url.Values{
+			"email":    {email},
+			"password": {string(password)},
+		}
+		res, err := http.PostForm(uri, values)
+		if err != nil {
+			ctx.WithError(err).Fatal("Registration failed")
+		}
+		defer res.Body.Close()
+
+		if res.StatusCode != http.StatusCreated {
+			ctx.Fatalf("Registration failed: %d %s", res.StatusCode, res.Status)
+		}
+
+		ctx.Info("User created")
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(usersCmd)
+	usersCmd.AddCommand(usersCreateCmd)
+
+	usersCmd.PersistentFlags().String("ttn-account-server", "account.thethings.network", "The Things Network OAuth 2.0 account server")
+	viper.BindPFlag("ttn-account-server", usersCmd.PersistentFlags().Lookup("ttn-account-server"))
+}

--- a/ttnctl/util/auth.go
+++ b/ttnctl/util/auth.go
@@ -1,0 +1,97 @@
+// Copyright © 2016 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package util
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path"
+)
+
+const (
+	authsFileName = ".ttnctl/auths.json"
+	authsFilePerm = 0600
+)
+
+// Auth represents an authentication token
+type Auth struct {
+	Token string `json:"token"`
+	Email string `json:"email"`
+}
+
+type auths struct {
+	Auths map[string]*Auth `json:"auths"`
+}
+
+// LoadAuth loads the authentication token for the specified server
+func LoadAuth(server string) (*Auth, error) {
+	a, err := loadAuths()
+	if err != nil {
+		return nil, err
+	}
+	return a.Auths[server], nil
+}
+
+// SaveAuth saves the authentication token for the specified server and e-mail
+func SaveAuth(server, email, token string) error {
+	a, err := loadAuths()
+	// Ignore error - just create new structure
+	if err != nil || a == nil {
+		a = &auths{}
+	}
+
+	// Initialize the map if not exists and add the token
+	if a.Auths == nil {
+		a.Auths = make(map[string]*Auth)
+	}
+	a.Auths[server] = &Auth{token, email}
+
+	// Marshal and write to disk
+	buff, err := json.Marshal(&a)
+	if err != nil {
+		return err
+	}
+	filename, err := getAuthsFilename()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(path.Dir(filename), 0755); err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(filename, buff, authsFilePerm); err != nil {
+		return err
+	}
+	return nil
+}
+
+// loadAuths loads the authentication tokens. This function always returns an
+// empty structure if the file does not exist.
+func loadAuths() (*auths, error) {
+	filename, err := getAuthsFilename()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := os.Stat(filename); os.IsNotExist(err) {
+		return &auths{}, nil
+	}
+	buff, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	var a auths
+	if err := json.Unmarshal(buff, &a); err != nil {
+		return nil, err
+	}
+	return &a, nil
+}
+
+func getAuthsFilename() (string, error) {
+	u, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+	return path.Join(u.HomeDir, authsFileName), nil
+}

--- a/ttnctl/util/auth.go
+++ b/ttnctl/util/auth.go
@@ -115,6 +115,15 @@ func NewRequestWithAuth(server, method, urlStr string, body io.Reader) (*http.Re
 	return req, nil
 }
 
+// RefreshToken refreshes the current token
+func RefreshToken(server string) (*Auth, error) {
+	auth, err := LoadAuth(server)
+	if err != nil {
+		return nil, err
+	}
+	return refreshToken(server, auth)
+}
+
 func refreshToken(server string, auth *Auth) (*Auth, error) {
 	values := url.Values{
 		"grant_type":    {"refresh_token"},

--- a/ttnctl/util/auth.go
+++ b/ttnctl/util/auth.go
@@ -7,9 +7,10 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
-	"os/user"
 	"path"
 	"time"
+
+	homedir "github.com/mitchellh/go-homedir"
 )
 
 const authsFilePerm = 0600
@@ -30,12 +31,15 @@ type auths struct {
 }
 
 func init() {
-	u, err := user.Current()
+	dir, err := homedir.Dir()
 	if err != nil {
-		// TODO: Should we support an alternative?
 		panic(err)
 	}
-	AuthsFileName = path.Join(u.HomeDir, ".ttnctl/auths.json")
+	expanded, err := homedir.Expand(dir)
+	if err != nil {
+		panic(err)
+	}
+	AuthsFileName = path.Join(expanded, ".ttnctl/auths.json")
 }
 
 // LoadAuth loads the authentication token for the specified server

--- a/ttnctl/util/auth.go
+++ b/ttnctl/util/auth.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/mitchellh/go-homedir"
 )
 
 const authsFilePerm = 0600
@@ -37,11 +37,11 @@ type auths struct {
 }
 
 type token struct {
-	AccessToken      string `json:"access_token"`
-	RefreshToken     string `json:"refresh_token"`
-	Error            string `json:"error"`
-	ErrorDescription string `json:"error_description"`
-	ExpiresIn        int    `json:"expires_in"`
+	AccessToken      string `json:"access_token,omitempty"`
+	RefreshToken     string `json:"refresh_token,omitempty"`
+	Error            string `json:"error,omitempty"`
+	ErrorDescription string `json:"error_description,omitempty"`
+	ExpiresIn        int    `json:"expires_in,omitempty"`
 }
 
 func init() {
@@ -160,8 +160,8 @@ func saveAuth(server, email, accessToken, refreshToken string, expires time.Time
 	return auth, nil
 }
 
-// loadAuths loads the authentication tokens. This function always returns an
-// empty structure if the file does not exist.
+// loadAuths loads the authentication tokens. This function returns an empty
+// structure if the file does not exist.
 func loadAuths() (*auths, error) {
 	if _, err := os.Stat(AuthsFileName); os.IsNotExist(err) {
 		return &auths{make(map[string]*Auth)}, nil

--- a/ttnctl/util/auth.go
+++ b/ttnctl/util/auth.go
@@ -21,9 +21,10 @@ var AuthsFileName string
 
 // Auth represents an authentication token
 type Auth struct {
-	Token   string    `json:"token"`
-	Email   string    `json:"email"`
-	Expires time.Time `json:"expires"`
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token"`
+	Email        string    `json:"email"`
+	Expires      time.Time `json:"expires"`
 }
 
 type auths struct {
@@ -56,7 +57,7 @@ func LoadAuth(server string) (*Auth, error) {
 }
 
 // SaveAuth saves the authentication token for the specified server and e-mail
-func SaveAuth(server, email, token string, expires time.Time) error {
+func SaveAuth(server, email, accessToken, refreshToken string, expires time.Time) error {
 	a, err := loadAuths()
 	// Ignore error - just create new structure
 	if err != nil || a == nil {
@@ -67,7 +68,7 @@ func SaveAuth(server, email, token string, expires time.Time) error {
 	if a.Auths == nil {
 		a.Auths = make(map[string]*Auth)
 	}
-	a.Auths[server] = &Auth{token, email, expires}
+	a.Auths[server] = &Auth{accessToken, refreshToken, email, expires}
 
 	// Marshal and write to disk
 	buff, err := json.Marshal(&a)

--- a/ttnctl/util/auth.go
+++ b/ttnctl/util/auth.go
@@ -91,7 +91,7 @@ func LoadAuth(server string) (*Auth, error) {
 	if !ok {
 		return nil, nil
 	}
-	if time.Now().After(auth.Expires) {
+	if time.Now().UTC().After(auth.Expires) {
 		return refreshToken(server, auth)
 	}
 	return auth, nil
@@ -152,7 +152,7 @@ func newToken(server, email string, values url.Values) (*Auth, error) {
 		return nil, errors.New(resp.Status)
 	}
 
-	expires := time.Now().Add(time.Duration(t.ExpiresIn) * time.Second)
+	expires := time.Now().UTC().Add(time.Duration(t.ExpiresIn) * time.Second)
 	auth, err := saveAuth(server, email, t.AccessToken, t.RefreshToken, expires)
 	if err != nil {
 		return nil, err

--- a/ttnctl/util/auth.go
+++ b/ttnctl/util/auth.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -94,6 +95,24 @@ func LoadAuth(server string) (*Auth, error) {
 		return refreshToken(server, auth)
 	}
 	return auth, nil
+}
+
+// NewRequestWithAuth creates a new HTTP request and adds the access token of
+// the authenticated user as bearer token
+func NewRequestWithAuth(server, method, urlStr string, body io.Reader) (*http.Request, error) {
+	auth, err := LoadAuth(server)
+	if err != nil {
+		return nil, err
+	}
+	if auth == nil {
+		return nil, errors.New("No authentication token found. Please login")
+	}
+	req, err := http.NewRequest(method, urlStr, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("bearer %s", auth.AccessToken))
+	return req, nil
 }
 
 func refreshToken(server string, auth *Auth) (*Auth, error) {

--- a/ttnctl/util/auth_test.go
+++ b/ttnctl/util/auth_test.go
@@ -95,6 +95,8 @@ func TestLogin(t *testing.T) {
 	a.So(err, ShouldBeNil)
 	a.So(loadedAuth, ShouldNotBeNil)
 	a.So(loginAuth, ShouldResemble, loadedAuth)
+
+	Logout(server.URL)
 }
 
 func TestLogout(t *testing.T) {
@@ -144,6 +146,8 @@ func TestLoadWithRefresh(t *testing.T) {
 	a.So(loadedAuth.AccessToken, ShouldEqual, "456")
 	a.So(loadedAuth.RefreshToken, ShouldEqual, "DEF")
 	a.So(loadedAuth.Email, ShouldEqual, "jantje@test.org")
+
+	Logout(server.URL)
 }
 
 func TestLoadWithInvalidRefresh(t *testing.T) {
@@ -165,4 +169,6 @@ func TestLoadWithInvalidRefresh(t *testing.T) {
 	a.So(err, ShouldNotBeNil)
 	a.So(err.Error(), ShouldEqual, "Refresh token not found")
 	a.So(loadedAuth, ShouldBeNil)
+
+	Logout(server.URL)
 }

--- a/ttnctl/util/auth_test.go
+++ b/ttnctl/util/auth_test.go
@@ -1,0 +1,147 @@
+package util
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/assertions"
+)
+
+func newTokenServer(a *Assertion) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		a.So(r.RequestURI, ShouldEqual, "/token")
+		a.So(r.Method, ShouldEqual, "POST")
+
+		username, password, ok := r.BasicAuth()
+		a.So(ok, ShouldBeTrue)
+		a.So(username, ShouldEqual, "ttnctl")
+		a.So(password, ShouldEqual, "")
+
+		grantType := r.FormValue("grant_type")
+		if grantType == "password" {
+			handleNewToken(a, w, r)
+		} else if grantType == "refresh_token" {
+			handleRefreshToken(a, w, r)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func handleNewToken(a *Assertion, w http.ResponseWriter, r *http.Request) {
+	var resp token
+	if r.FormValue("username") == "jantje@test.org" && r.FormValue("password") == "secret" {
+		resp = token{
+			AccessToken:  "123",
+			RefreshToken: "ABC",
+			ExpiresIn:    3600,
+		}
+		w.WriteHeader(http.StatusOK)
+	} else {
+		resp = token{
+			Error:            "invalid_credentials",
+			ErrorDescription: "Invalid credentials",
+		}
+		w.WriteHeader(http.StatusForbidden)
+	}
+
+	encoder := json.NewEncoder(w)
+	err := encoder.Encode(&resp)
+	a.So(err, ShouldBeNil)
+}
+
+func handleRefreshToken(a *Assertion, w http.ResponseWriter, r *http.Request) {
+	var resp token
+	if r.FormValue("refresh_token") == "ABC" {
+		resp = token{
+			AccessToken:  "456",
+			RefreshToken: "DEF",
+			ExpiresIn:    3600,
+		}
+		w.WriteHeader(http.StatusOK)
+	} else {
+		resp = token{
+			Error:            "invalid_grant",
+			ErrorDescription: "Refresh token not found",
+		}
+		w.WriteHeader(http.StatusBadRequest)
+	}
+
+	encoder := json.NewEncoder(w)
+	err := encoder.Encode(&resp)
+	a.So(err, ShouldBeNil)
+}
+
+func TestLogin(t *testing.T) {
+	a := New(t)
+	server := newTokenServer(a)
+	defer server.Close()
+
+	_, err := Login(server.URL, "pietje@test.org", "secret")
+	a.So(err, ShouldNotBeNil)
+	a.So(err.Error(), ShouldEqual, "Invalid credentials")
+
+	loginAuth, err := Login(server.URL, "jantje@test.org", "secret")
+	a.So(err, ShouldBeNil)
+	a.So(loginAuth, ShouldNotBeNil)
+	a.So(loginAuth.AccessToken, ShouldEqual, "123")
+	a.So(loginAuth.RefreshToken, ShouldEqual, "ABC")
+	a.So(loginAuth.Email, ShouldEqual, "jantje@test.org")
+
+	loadedAuth, err := LoadAuth(server.URL)
+	a.So(err, ShouldBeNil)
+	a.So(loadedAuth, ShouldNotBeNil)
+	a.So(loginAuth, ShouldResemble, loadedAuth)
+}
+
+func TestLogout(t *testing.T) {
+	a := New(t)
+	server := newTokenServer(a)
+	defer server.Close()
+
+	// Make sure we're not logged on
+	err := Logout(server.URL)
+	a.So(err, ShouldBeNil)
+	loadedAuth, err := LoadAuth(server.URL)
+	a.So(err, ShouldBeNil)
+	a.So(loadedAuth, ShouldBeNil)
+
+	// Login
+	loginAuth, err := Login(server.URL, "jantje@test.org", "secret")
+	a.So(err, ShouldBeNil)
+	a.So(loginAuth, ShouldNotBeNil)
+
+	// Logout
+	err = Logout(server.URL)
+	a.So(err, ShouldBeNil)
+	loadedAuth, err = LoadAuth(server.URL)
+	a.So(err, ShouldBeNil)
+	a.So(loadedAuth, ShouldBeNil)
+}
+
+func TestLoadWithRefresh(t *testing.T) {
+	a := New(t)
+	server := newTokenServer(a)
+	defer server.Close()
+
+	// Make sure we're not logged on
+	err := Logout(server.URL)
+	a.So(err, ShouldBeNil)
+
+	// Save an expired token
+	expires := time.Now().Add(time.Duration(-1) * time.Hour)
+	savedAuth, err := saveAuth(server.URL, "jantje@test.org", "123", "ABC", expires)
+	a.So(err, ShouldBeNil)
+
+	// Refresh the token
+	loadedAuth, err := LoadAuth(server.URL)
+	a.So(err, ShouldBeNil)
+	a.So(loadedAuth, ShouldNotBeNil)
+	a.So(savedAuth, ShouldNotResemble, loadedAuth)
+	a.So(loadedAuth.AccessToken, ShouldEqual, "456")
+	a.So(loadedAuth.RefreshToken, ShouldEqual, "DEF")
+	a.So(loadedAuth.Email, ShouldEqual, "jantje@test.org")
+}

--- a/ttnctl/util/auth_test.go
+++ b/ttnctl/util/auth_test.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -96,6 +97,12 @@ func TestLogin(t *testing.T) {
 	a.So(loadedAuth, ShouldNotBeNil)
 	a.So(loginAuth, ShouldResemble, loadedAuth)
 
+	// Check if we get this token on the HTTP request
+	req, err := NewRequestWithAuth(server.URL, "GET", "http://external", nil)
+	a.So(err, ShouldBeNil)
+	a.So(req, ShouldNotBeNil)
+	a.So(req.Header.Get("Authorization"), ShouldEqual, fmt.Sprintf("bearer %s", loadedAuth.AccessToken))
+
 	Logout(server.URL)
 }
 
@@ -122,6 +129,10 @@ func TestLogout(t *testing.T) {
 	loadedAuth, err = LoadAuth(server.URL)
 	a.So(err, ShouldBeNil)
 	a.So(loadedAuth, ShouldBeNil)
+
+	// Make sure that we can't make an HTTP request
+	_, err = NewRequestWithAuth(server.URL, "GET", "http://external", nil)
+	a.So(err, ShouldNotBeNil)
 }
 
 func TestLoadWithRefresh(t *testing.T) {

--- a/ttnctl/util/auth_test.go
+++ b/ttnctl/util/auth_test.go
@@ -145,3 +145,24 @@ func TestLoadWithRefresh(t *testing.T) {
 	a.So(loadedAuth.RefreshToken, ShouldEqual, "DEF")
 	a.So(loadedAuth.Email, ShouldEqual, "jantje@test.org")
 }
+
+func TestLoadWithInvalidRefresh(t *testing.T) {
+	a := New(t)
+	server := newTokenServer(a)
+	defer server.Close()
+
+	// Make sure we're not logged on
+	err := Logout(server.URL)
+	a.So(err, ShouldBeNil)
+
+	// Save an expired token
+	expires := time.Now().Add(time.Duration(-1) * time.Hour)
+	_, err = saveAuth(server.URL, "pietje@test.org", "987", "ZYX", expires)
+	a.So(err, ShouldBeNil)
+
+	// Refresh the token
+	loadedAuth, err := LoadAuth(server.URL)
+	a.So(err, ShouldNotBeNil)
+	a.So(err.Error(), ShouldEqual, "Refresh token not found")
+	a.So(loadedAuth, ShouldBeNil)
+}


### PR DESCRIPTION
Key is loaded from file `~/.ttn/oauth2-token.pub` but user can specify a different location using an environment variable or setting the `--oauth2-keyfile` flag. Because of the nature and size of this key, I think it should be a file and not putting the key as hex formatted string in an environment variable.

Note: the current PR breaks tests.