### PR TITLE
Ask user to retype password to prevent typing errors when creating user

### DIFF
--- a/ttnctl/cmd/user.go
+++ b/ttnctl/cmd/user.go
@@ -4,10 +4,10 @@
 package cmd
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"net/url"
-	"bytes"
 
 	"github.com/TheThingsNetwork/ttn/ttnctl/util"
 	"github.com/howeyc/gopass"

--- a/ttnctl/cmd/user.go
+++ b/ttnctl/cmd/user.go
@@ -55,7 +55,7 @@ var userCreateCmd = &cobra.Command{
 		if err != nil {
 			ctx.Fatal(err.Error())
 		}
-		if ! reflect.DeepEqual(password,password2) {
+		if !reflect.DeepEqual(password, password2) {
 			ctx.Fatal("Passwords do not match")
 		}
 

--- a/ttnctl/cmd/user.go
+++ b/ttnctl/cmd/user.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"reflect"
+	"bytes"
 
 	"github.com/TheThingsNetwork/ttn/ttnctl/util"
 	"github.com/howeyc/gopass"
@@ -50,12 +50,12 @@ var userCreateCmd = &cobra.Command{
 		if err != nil {
 			ctx.Fatal(err.Error())
 		}
-		fmt.Print("Retype password: ")
+		fmt.Print("Confirm password: ")
 		password2, err := gopass.GetPasswd()
 		if err != nil {
 			ctx.Fatal(err.Error())
 		}
-		if !reflect.DeepEqual(password, password2) {
+		if !bytes.Equal(password, password2) {
 			ctx.Fatal("Passwords do not match")
 		}
 

--- a/ttnctl/cmd/user.go
+++ b/ttnctl/cmd/user.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"reflect"
 
 	"github.com/TheThingsNetwork/ttn/ttnctl/util"
 	"github.com/howeyc/gopass"
@@ -48,6 +49,14 @@ var userCreateCmd = &cobra.Command{
 		password, err := gopass.GetPasswd()
 		if err != nil {
 			ctx.Fatal(err.Error())
+		}
+		fmt.Print("Retype password: ")
+		password2, err := gopass.GetPasswd()
+		if err != nil {
+			ctx.Fatal(err.Error())
+		}
+		if ! reflect.DeepEqual(password,password2) {
+			ctx.Fatal("Passwords do not match")
 		}
 
 		uri := fmt.Sprintf("%s/register", viper.GetString("ttn-account-server"))


### PR DESCRIPTION
Update to ttnctl utility to catch typos while creating accounts.