### PR TITLE
add IsEmpty to core types

### DIFF
--- a/core/types/dev_addr.go
+++ b/core/types/dev_addr.go
@@ -73,3 +73,9 @@ func (addr *DevAddr) Unmarshal(data []byte) error {
 	*addr = [4]byte{} // Reset the receiver
 	return addr.UnmarshalBinary(data)
 }
+
+var empty DevAddr
+
+func (addr DevAddr) IsEmpty() bool {
+	return addr == empty
+}

--- a/core/types/dev_addr_test.go
+++ b/core/types/dev_addr_test.go
@@ -57,4 +57,9 @@ func TestDevAddr(t *testing.T) {
 	err = uOut.Unmarshal(bin)
 	a.So(err, ShouldBeNil)
 	a.So(*uOut, ShouldEqual, addr)
+
+	// IsEmpty
+	var empty DevAddr
+	a.So(empty.IsEmpty(), ShouldEqual, true)
+	a.So(addr.IsEmpty(), ShouldEqual, false)
 }

--- a/core/types/eui.go
+++ b/core/types/eui.go
@@ -285,3 +285,21 @@ func (eui *GatewayEUI) Unmarshal(data []byte) error {
 	*eui = [8]byte{} // Reset the receiver
 	return eui.UnmarshalBinary(data)
 }
+
+var emptyEUI64 EUI64
+
+func (eui EUI64) IsEmpty() bool {
+	return eui == emptyEUI64
+}
+
+func (eui DevEUI) IsEmpty() bool {
+	return EUI64(eui).IsEmpty()
+}
+
+func (eui AppEUI) IsEmpty() bool {
+	return EUI64(eui).IsEmpty()
+}
+
+func (eui GatewayEUI) IsEmpty() bool {
+	return EUI64(eui).IsEmpty()
+}

--- a/core/types/eui_test.go
+++ b/core/types/eui_test.go
@@ -57,6 +57,11 @@ func TestEUI64(t *testing.T) {
 	err = uOut.Unmarshal(bin)
 	a.So(err, ShouldBeNil)
 	a.So(uOut, ShouldResemble, &eui)
+
+	// IsEmpty
+	var empty EUI64
+	a.So(empty.IsEmpty(), ShouldEqual, true)
+	a.So(eui.IsEmpty(), ShouldEqual, false)
 }
 
 func TestAppEUI(t *testing.T) {
@@ -110,6 +115,11 @@ func TestAppEUI(t *testing.T) {
 	err = uOut.Unmarshal(bin)
 	a.So(err, ShouldBeNil)
 	a.So(*uOut, ShouldEqual, eui)
+
+	// IsEmpty
+	var empty AppEUI
+	a.So(empty.IsEmpty(), ShouldEqual, true)
+	a.So(eui.IsEmpty(), ShouldEqual, false)
 }
 
 func TestDevEUI(t *testing.T) {
@@ -163,6 +173,11 @@ func TestDevEUI(t *testing.T) {
 	err = uOut.Unmarshal(bin)
 	a.So(err, ShouldBeNil)
 	a.So(*uOut, ShouldEqual, eui)
+
+	// IsEmpty
+	var empty DevEUI
+	a.So(empty.IsEmpty(), ShouldEqual, true)
+	a.So(eui.IsEmpty(), ShouldEqual, false)
 }
 
 func TestGatewayEUI(t *testing.T) {
@@ -216,4 +231,9 @@ func TestGatewayEUI(t *testing.T) {
 	err = uOut.Unmarshal(bin)
 	a.So(err, ShouldBeNil)
 	a.So(*uOut, ShouldEqual, eui)
+
+	// IsEmpty
+	var empty GatewayEUI
+	a.So(empty.IsEmpty(), ShouldEqual, true)
+	a.So(eui.IsEmpty(), ShouldEqual, false)
 }

--- a/core/types/keys.go
+++ b/core/types/keys.go
@@ -284,3 +284,21 @@ func (key *NwkSKey) Unmarshal(data []byte) error {
 	*key = [16]byte{} // Reset the receiver
 	return key.UnmarshalBinary(data)
 }
+
+var emptyAES AES128Key
+
+func (key AES128Key) IsEmpty() bool {
+	return key == emptyAES
+}
+
+func (key AppKey) IsEmpty() bool {
+	return AES128Key(key).IsEmpty()
+}
+
+func (key AppSKey) IsEmpty() bool {
+	return AES128Key(key).IsEmpty()
+}
+
+func (key NwkSKey) IsEmpty() bool {
+	return AES128Key(key).IsEmpty()
+}

--- a/core/types/keys_test.go
+++ b/core/types/keys_test.go
@@ -57,6 +57,11 @@ func TestAES128Key(t *testing.T) {
 	err = uOut.Unmarshal(bin)
 	a.So(err, ShouldBeNil)
 	a.So(*uOut, ShouldEqual, key)
+
+	// IsEmpty
+	var empty AES128Key
+	a.So(empty.IsEmpty(), ShouldBeTrue)
+	a.So(key.IsEmpty(), ShouldBeFalse)
 }
 
 func TestAppKey(t *testing.T) {
@@ -110,6 +115,11 @@ func TestAppKey(t *testing.T) {
 	err = uOut.Unmarshal(bin)
 	a.So(err, ShouldBeNil)
 	a.So(*uOut, ShouldEqual, key)
+
+	// IsEmpty
+	var empty AppKey
+	a.So(empty.IsEmpty(), ShouldBeTrue)
+	a.So(key.IsEmpty(), ShouldBeFalse)
 }
 
 func TestNwkSKey(t *testing.T) {
@@ -163,6 +173,11 @@ func TestNwkSKey(t *testing.T) {
 	err = uOut.Unmarshal(bin)
 	a.So(err, ShouldBeNil)
 	a.So(*uOut, ShouldEqual, key)
+
+	// IsEmpty
+	var empty NwkSKey
+	a.So(empty.IsEmpty(), ShouldBeTrue)
+	a.So(key.IsEmpty(), ShouldBeFalse)
 }
 
 func TestAppSKey(t *testing.T) {
@@ -216,4 +231,9 @@ func TestAppSKey(t *testing.T) {
 	err = uOut.Unmarshal(bin)
 	a.So(err, ShouldBeNil)
 	a.So(*uOut, ShouldEqual, key)
+
+	// IsEmpty
+	var empty AppSKey
+	a.So(empty.IsEmpty(), ShouldBeTrue)
+	a.So(key.IsEmpty(), ShouldBeFalse)
 }


### PR DESCRIPTION
This pull request adds the `IsEmpty` method on all core types. `IsEmpty` is a helper function that checks if the value under consideration is the default value for this type (for instance `000000000000000` for an `AppEUI`).