### PR TITLE
Fix for join issues mentioned in "EU RX2 parameters #155", ...

### DIFF
--- a/core/components/handler/handler.go
+++ b/core/components/handler/handler.go
@@ -461,7 +461,7 @@ func (h component) consumeJoin(appEUI []byte, devEUI []byte, appKey [16]byte, re
 	}
 
 	// Check if at least one is available
-	best := computer.Get(scores)
+	best := computer.Get(scores, true)
 	ctx.WithField("Best", best).Debug("Determine best response gateway")
 	if best == nil {
 		h.abortConsume(errors.New(errors.Operational, "No gateway is available for an answer"), bundles)
@@ -604,7 +604,7 @@ func (h component) consumeDown(appEUI []byte, devEUI []byte, region dutycycle.Re
 	stats.MarkMeter("handler.uplink.out")
 
 	// Now handle the downlink and respond to node
-	best := computer.Get(scores)
+	best := computer.Get(scores, false)
 	var downlink pktEntry
 	if best != nil { // Avoid pulling when there's no gateway available for an answer
 		downlink, err = h.PktStorage.dequeue(appEUI, devEUI)

--- a/core/dutycycle/scoreComputer.go
+++ b/core/dutycycle/scoreComputer.go
@@ -83,7 +83,7 @@ func (c *ScoreComputer) Update(s scores, id int, metadata core.Metadata) scores 
 
 // Get returns the best score according to the configured spread factor and all updates.
 // It returns nil if none of the target is available for a response
-func (c *ScoreComputer) Get(s scores) *Configuration {
+func (c *ScoreComputer) Get(s scores, isJoin bool) *Configuration {
 	sf, bw, _ := ParseDatr(s.rx1.DataRate)
 	dataRate := band.DataRate{
 		Modulation:   band.LoRaModulation,
@@ -106,14 +106,26 @@ func (c *ScoreComputer) Get(s scores) *Configuration {
 			}
 		}
 		if s.rx2.Score > 0 {
-			return &Configuration{
-				ID:        s.rx2.ID,
-				Frequency: 869.525,
-				DataRate:  "SF9BW125",
-				Power:     27,
-				RXDelay:   2000000,
-				JoinDelay: 6000000,
-				CFList:    [5]uint32{867100000, 867300000, 867500000, 867700000, 867900000},
+			if isJoin {
+				return &Configuration{
+					ID:        s.rx2.ID,
+					Frequency: 869.525,
+					DataRate:  "SF12BW125",
+					Power:     27,
+					RXDelay:   2000000,
+					JoinDelay: 6000000,
+					CFList:    [5]uint32{867100000, 867300000, 867500000, 867700000, 867900000},
+				}
+			} else {
+				return &Configuration{
+					ID:        s.rx2.ID,
+					Frequency: 869.525,
+					DataRate:  "SF9BW125",
+					Power:     27,
+					RXDelay:   2000000,
+					JoinDelay: 6000000,
+					CFList:    [5]uint32{867100000, 867300000, 867500000, 867700000, 867900000},
+				}
 			}
 		}
 	case US:

--- a/core/dutycycle/scoreComputer_test.go
+++ b/core/dutycycle/scoreComputer_test.go
@@ -60,7 +60,6 @@ func TestUpdateGet(t *testing.T) {
 
 	rx1cfg := &Configuration{ID: 1, RXDelay: 1000000, JoinDelay: 5000000, Power: 14, CFList: [5]uint32{867100000, 867300000, 867500000, 867700000, 867900000}}
 	rx2cfg := &Configuration{ID: 1, Frequency: 869.525, DataRate: "SF9BW125", RXDelay: 2000000, JoinDelay: 6000000, Power: 27, CFList: [5]uint32{867100000, 867300000, 867500000, 867700000, 867900000}}
-	rx2joincfg := &Configuration{ID: 1, Frequency: 869.525, DataRate: "SF12BW125", RXDelay: 2000000, JoinDelay: 6000000, Power: 27, CFList: [5]uint32{867100000, 867300000, 867500000, 867700000, 867900000}}
 
 	{
 		Desc(t, "SF7 | (1, Av, Bl, -25, 5.0)")

--- a/core/dutycycle/scoreComputer_test.go
+++ b/core/dutycycle/scoreComputer_test.go
@@ -46,10 +46,11 @@ func TestUpdateGet(t *testing.T) {
 
 		// Build
 		c, s, err := NewScoreComputer(World, "SF7BW125")
+		join := false
 		CheckErrors(t, nil, err)
 
 		// Operate
-		got := c.Get(s)
+		got := c.Get(s, join)
 
 		// Check
 		CheckConfiguration(t, nil, got)
@@ -59,12 +60,14 @@ func TestUpdateGet(t *testing.T) {
 
 	rx1cfg := &Configuration{ID: 1, RXDelay: 1000000, JoinDelay: 5000000, Power: 14, CFList: [5]uint32{867100000, 867300000, 867500000, 867700000, 867900000}}
 	rx2cfg := &Configuration{ID: 1, Frequency: 869.525, DataRate: "SF9BW125", RXDelay: 2000000, JoinDelay: 6000000, Power: 27, CFList: [5]uint32{867100000, 867300000, 867500000, 867700000, 867900000}}
+	rx2joincfg := &Configuration{ID: 1, Frequency: 869.525, DataRate: "SF12BW125", RXDelay: 2000000, JoinDelay: 6000000, Power: 27, CFList: [5]uint32{867100000, 867300000, 867500000, 867700000, 867900000}}
 
 	{
 		Desc(t, "SF7 | (1, Av, Bl, -25, 5.0)")
 
 		// Build
 		c, s, err := NewScoreComputer(Europe, "SF7BW125")
+		join := false
 		CheckErrors(t, nil, err)
 
 		// Operate
@@ -74,7 +77,7 @@ func TestUpdateGet(t *testing.T) {
 			Rssi:    -25,
 			Lsnr:    5.0,
 		})
-		got := c.Get(s)
+		got := c.Get(s, join)
 
 		// Check
 		CheckConfiguration(t, rx1cfg, got)
@@ -87,6 +90,7 @@ func TestUpdateGet(t *testing.T) {
 
 		// Build
 		c, s, err := NewScoreComputer(Europe, "SF7BW125")
+		join := false
 		CheckErrors(t, nil, err)
 
 		// Operate
@@ -96,7 +100,7 @@ func TestUpdateGet(t *testing.T) {
 			Rssi:    -25,
 			Lsnr:    5.0,
 		})
-		got := c.Get(s)
+		got := c.Get(s, join)
 
 		// Check
 		CheckConfiguration(t, rx2cfg, got)
@@ -109,6 +113,7 @@ func TestUpdateGet(t *testing.T) {
 
 		// Build
 		c, s, err := NewScoreComputer(Europe, "SF7BW125")
+		join := false
 		CheckErrors(t, nil, err)
 
 		// Operate
@@ -118,7 +123,7 @@ func TestUpdateGet(t *testing.T) {
 			Rssi:    -25,
 			Lsnr:    5.0,
 		})
-		got := c.Get(s)
+		got := c.Get(s, join)
 
 		// Check
 		CheckConfiguration(t, nil, got)
@@ -131,6 +136,7 @@ func TestUpdateGet(t *testing.T) {
 
 		// Build
 		c, s, err := NewScoreComputer(Europe, "SF9BW125")
+		join := false
 		CheckErrors(t, nil, err)
 
 		// Operate
@@ -140,7 +146,7 @@ func TestUpdateGet(t *testing.T) {
 			Rssi:    -25,
 			Lsnr:    5.0,
 		})
-		got := c.Get(s)
+		got := c.Get(s, join)
 
 		// Check
 		CheckConfiguration(t, rx2cfg, got)
@@ -153,6 +159,7 @@ func TestUpdateGet(t *testing.T) {
 
 		// Build
 		c, s, err := NewScoreComputer(Europe, "SF10BW125")
+		join := false
 		CheckErrors(t, nil, err)
 
 		// Operate
@@ -168,7 +175,7 @@ func TestUpdateGet(t *testing.T) {
 			Rssi:    -25,
 			Lsnr:    3.0,
 		})
-		got := c.Get(s)
+		got := c.Get(s, join)
 
 		// Check
 		CheckConfiguration(t, rx2cfg, got)
@@ -181,6 +188,7 @@ func TestUpdateGet(t *testing.T) {
 
 		// Build
 		c, s, err := NewScoreComputer(Europe, "SF10BW125")
+		join := false
 		CheckErrors(t, nil, err)
 
 		// Operate
@@ -190,7 +198,7 @@ func TestUpdateGet(t *testing.T) {
 			Rssi:    -25,
 			Lsnr:    5.0,
 		})
-		got := c.Get(s)
+		got := c.Get(s, join)
 
 		// Check
 		CheckConfiguration(t, nil, got)
@@ -203,6 +211,7 @@ func TestUpdateGet(t *testing.T) {
 
 		// Build
 		c, s, err := NewScoreComputer(Europe, "SF8BW125")
+		join := false
 		CheckErrors(t, nil, err)
 
 		// Operate
@@ -218,7 +227,7 @@ func TestUpdateGet(t *testing.T) {
 			Rssi:    -25,
 			Lsnr:    5.0,
 		})
-		got := c.Get(s)
+		got := c.Get(s, join)
 
 		// Check
 		CheckConfiguration(t, &Configuration{ID: 2, RXDelay: 1000000, JoinDelay: 5000000, Power: 14, CFList: [5]uint32{867100000, 867300000, 867500000, 867700000, 867900000}}, got)
@@ -231,6 +240,7 @@ func TestUpdateGet(t *testing.T) {
 
 		// Build
 		c, s, err := NewScoreComputer(Europe, "SF12BW125")
+		join := false
 		CheckErrors(t, nil, err)
 
 		// Operate
@@ -246,7 +256,7 @@ func TestUpdateGet(t *testing.T) {
 			Rssi:    -25,
 			Lsnr:    3.4,
 		})
-		got := c.Get(s)
+		got := c.Get(s, join)
 
 		// Check
 		CheckConfiguration(t, rx2cfg, got)


### PR DESCRIPTION
Pull request for feature/us-frequencies branch.

Modified the code to make sure JoinAccepts in RX2 get transmitted using SF12 as per LoRaWAN standard. Did not change scoreComputer to schedule response packets for SF7-SF11 in RX1 as it does not make sense given Thomas's remark concerning duty cycles of those channels.

As this patch does not fix the mentioned LMiC issues nor the requirement to set RX2 to SF9 for ABP nodes.