### PR TITLE
Bugfix/payload fns array panic

### DIFF
--- a/core/adapters/fields/functions.go
+++ b/core/adapters/fields/functions.go
@@ -45,7 +45,11 @@ func (f *Functions) Decode(payload []byte) (map[string]interface{}, error) {
 	}
 
 	v, _ := value.Export()
-	return v.(map[string]interface{}), nil
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return nil, errors.New("Decoder does not return an object")
+	}
+	return m, nil
 }
 
 // Convert converts the values in the specified map to a another map using the
@@ -68,7 +72,12 @@ func (f *Functions) Convert(data map[string]interface{}) (map[string]interface{}
 	}
 
 	v, _ := value.Export()
-	return v.(map[string]interface{}), nil
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return nil, errors.New("Decoder does not return an object")
+	}
+
+	return m, nil
 }
 
 // Validate validates the values in the specified map using the Validator

--- a/core/adapters/fields/functions_test.go
+++ b/core/adapters/fields/functions_test.go
@@ -153,6 +153,23 @@ func TestProcessInvalidFunction(t *testing.T) {
 	}
 	_, _, err = functions.Process([]byte{40, 110})
 	a.So(err, ShouldNotBeNil)
+
+	// Invalid Object (Arrays are Objects too, but don't jive well with
+	// map[string]interface{})
+	functions = &Functions{
+		Decoder: `function(payload) { return [1] }`,
+	}
+	_, _, err = functions.Process([]byte{40, 110})
+	a.So(err, ShouldNotBeNil)
+
+	// Invalid Object (Arrays are Objects too, but don't jive well with
+	// map[string]interface{})
+	functions = &Functions{
+		Decoder:   `function(payload) { return { temperature: payload[0] } }`,
+		Converter: `function(payload) { return [1] }`,
+	}
+	_, _, err = functions.Process([]byte{40, 110})
+	a.So(err, ShouldNotBeNil)
 }
 
 func TestTimeoutExceeded(t *testing.T) {

--- a/core/adapters/fields/functions_test.go
+++ b/core/adapters/fields/functions_test.go
@@ -170,6 +170,15 @@ func TestProcessInvalidFunction(t *testing.T) {
 	}
 	_, _, err = functions.Process([]byte{40, 110})
 	a.So(err, ShouldNotBeNil)
+
+	// Invalid Object (Arrays are Objects too), this should work error because
+	// we're expecting a Boolean
+	functions = &Functions{
+		Decoder:   `function(payload) { return { temperature: payload[0] } }`,
+		Validator: `function(payload) { return [1] }`,
+	}
+	_, _, err = functions.Process([]byte{40, 110})
+	a.So(err, ShouldNotBeNil)
 }
 
 func TestTimeoutExceeded(t *testing.T) {


### PR DESCRIPTION
A payload decoder or converter like:
```js
function (payload) {
  return [1];
}
```
will crash the handler due to an invalid cast.

This PR fixes that by checking if the cast is valid.