### PR TITLE
add helper to convert DevAddr to DevEUI

### DIFF
--- a/core/types/dev_addr.go
+++ b/core/types/dev_addr.go
@@ -80,10 +80,11 @@ func (addr DevAddr) IsEmpty() bool {
 	return addr == empty
 }
 
-var prefix = []byte{0, 0, 0, 0}
+// ABPEUIPrefix is the prefix denoting a prefixed dev address
+var ABPEUIPrefix = []byte{0, 0, 0, 0}
 
 func (addr DevAddr) ToEUI() DevEUI {
 	var devEUI DevEUI
-	devEUI.UnmarshalBinary(append(prefix, addr.Bytes()...))
+	devEUI.UnmarshalBinary(append(ABPEUIPrefix, addr.Bytes()...))
 	return devEUI
 }

--- a/core/types/dev_addr.go
+++ b/core/types/dev_addr.go
@@ -79,3 +79,11 @@ var empty DevAddr
 func (addr DevAddr) IsEmpty() bool {
 	return addr == empty
 }
+
+var prefix = []byte{0, 0, 0, 0}
+
+func (addr DevAddr) ToEUI() DevEUI {
+	var devEUI DevEUI
+	devEUI.UnmarshalBinary(append(prefix, addr.Bytes()...))
+	return devEUI
+}

--- a/core/types/dev_addr_test.go
+++ b/core/types/dev_addr_test.go
@@ -62,4 +62,8 @@ func TestDevAddr(t *testing.T) {
 	var empty DevAddr
 	a.So(empty.IsEmpty(), ShouldEqual, true)
 	a.So(addr.IsEmpty(), ShouldEqual, false)
+
+	// ToEUI
+	eui := DevEUI{0, 0, 0, 0, 1, 2, 254, 255}
+	a.So(addr.ToEUI(), ShouldEqual, eui)
 }


### PR DESCRIPTION
Adds a helper fn on the type `DevAddr` to create a `DevEUI` from it:

```go
addr := types.DevAddr{1,2,3,4}
eui := addr.ToEUI()
// is the same as
eui := types.DevEUI{0, 0, 0, 0, 1, 2, 3, 4}
```