### PR TITLE
Bugfix/encoder types

### DIFF
--- a/core/handler/convert_fields.go
+++ b/core/handler/convert_fields.go
@@ -234,7 +234,18 @@ func (f *DownlinkFunctions) Encode(payload map[string]interface{}) ([]byte, erro
 			n = int64(t)
 		case uint64:
 			n = int64(t)
+		case float32:
+			n = int64(t)
+			if float32(n) != t {
+				return nil, errors.New("Encoder should return an Array of integer numbers")
+			}
+		case float64:
+			n = int64(t)
+			if float64(n) != t {
+				return nil, errors.New("Encoder should return an Array of integer numbers")
+			}
 		default:
+			fmt.Printf("VAL %v TYPE %T\n", el, el)
 			return nil, errors.New("Encoder should return an Array of integer numbers")
 		}
 

--- a/core/handler/convert_fields.go
+++ b/core/handler/convert_fields.go
@@ -228,9 +228,11 @@ func (f *DownlinkFunctions) Encode(payload map[string]interface{}) ([]byte, erro
 			n = int64(t)
 		case int:
 			n = int64(t)
-		case int64:
+		case int32:
 			n = int64(t)
 		case uint32:
+			n = int64(t)
+		case int64:
 			n = int64(t)
 		case uint64:
 			n = int64(t)

--- a/core/handler/convert_fields.go
+++ b/core/handler/convert_fields.go
@@ -6,6 +6,7 @@ package handler
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"time"
 
 	pb_broker "github.com/TheThingsNetwork/ttn/api/broker"
@@ -207,17 +208,41 @@ func (f *DownlinkFunctions) Encode(payload map[string]interface{}) ([]byte, erro
 		return nil, err
 	}
 
-	m, ok := v.([]int64)
-	if !ok {
-		return nil, errors.New("Encoder should return an Array of numbers")
+	if reflect.TypeOf(v).Kind() != reflect.Slice {
+		return nil, errors.New("Encoder does not return an array")
 	}
 
-	res := make([]byte, len(m))
-	for i, v := range m {
-		if v < 0 || v > 255 {
+	s := reflect.ValueOf(v)
+	l := s.Len()
+
+	res := make([]byte, l)
+
+	var n int64
+	for i := 0; i < l; i++ {
+		el := s.Index(i).Interface()
+
+		// type switch does not have falltrought so we need
+		// to check every element individually
+		switch t := el.(type) {
+		case byte:
+			n = int64(t)
+		case int:
+			n = int64(t)
+		case int64:
+			n = int64(t)
+		case uint32:
+			n = int64(t)
+		case uint64:
+			n = int64(t)
+		default:
+			return nil, errors.New("Encoder should return an Array of integer numbers")
+		}
+
+		if n < 0 || n > 255 {
 			return nil, errors.New("Numbers in array should be between 0 and 255")
 		}
-		res[i] = byte(v)
+
+		res[i] = byte(n)
 	}
 
 	return res, nil

--- a/core/handler/convert_fields.go
+++ b/core/handler/convert_fields.go
@@ -221,7 +221,7 @@ func (f *DownlinkFunctions) Encode(payload map[string]interface{}) ([]byte, erro
 	for i := 0; i < l; i++ {
 		el := s.Index(i).Interface()
 
-		// type switch does not have falltrought so we need
+		// type switch does not have fallthrough so we need
 		// to check every element individually
 		switch t := el.(type) {
 		case byte:

--- a/core/handler/convert_fields_test.go
+++ b/core/handler/convert_fields_test.go
@@ -292,6 +292,13 @@ func TestEncode(t *testing.T) {
 
 	a.So(m, ShouldHaveLength, 7)
 	a.So(m, ShouldResemble, []byte{1, 2, 3, 4, 5, 6, 7})
+
+	// Return int type
+	functions = &DownlinkFunctions{
+		Encoder: `function(payload) { var x = [1, 2, 3 ]; return [ x.length || 0 ] }`,
+	}
+	_, _, err = functions.Process(map[string]interface{}{"key": 11})
+	a.So(err, ShouldBeNil)
 }
 
 func buildConversionDownlink() (*pb_broker.DownlinkMessage, *mqtt.DownlinkMessage) {
@@ -333,6 +340,7 @@ func TestConvertFieldsDown(t *testing.T) {
   		return [ 1, 2, 3, 4, 5, 6, 7 ]
 		}`,
 	})
+
 	ttnDown, appDown = buildConversionDownlink()
 	err = h.ConvertFieldsDown(GetLogger(t, "TestConvertFieldsDown"), appDown, ttnDown)
 	a.So(err, ShouldBeNil)

--- a/core/handler/convert_fields_test.go
+++ b/core/handler/convert_fields_test.go
@@ -396,4 +396,10 @@ func TestProcessDownlinkInvalidFunction(t *testing.T) {
 	}
 	_, _, err = functions.Process(map[string]interface{}{"key": 11})
 	a.So(err, ShouldNotBeNil)
+
+	functions = &DownlinkFunctions{
+		Encoder: `function(payload) { return [ 1, 1.5 ] }`,
+	}
+	_, _, err = functions.Process(map[string]interface{}{"key": 11})
+	a.So(err, ShouldNotBeNil)
 }


### PR DESCRIPTION
Fixes a bug where the encoding of payloads would not work as expected because of mismatched integer types. For instance, the encoder:
```js
function Encoder(fields) {
  return fields.foo;
}
```

With `fields = [1, 2, 3] ` returns the error `Encoder should return an Array of numbers`. This is not correct because you'd expect this to work (all values in the array are integers between 0 an 255).

This PR fixes that by allowing more types (`byte`, `int`, `int32`, `uint32`, `int64`, `uint64`, `float32` and `float64`) to be returned. In case of the floating point types, it returns an error when the value is not an integer value.

