### PR TITLE
Edit title and add auth info in MQTT readme

### DIFF
--- a/mqtt/README.md
+++ b/mqtt/README.md
@@ -1,7 +1,10 @@
-# The Things Network MQTT
+# API Reference
 
-This package contains the code that is used to publish and subscribe to MQTT.
-This README describes the topics and messages that are used 
+* Host: `<Region>.thethings.network`
+* Port: `1883`
+* TLS: Not yet available
+* Username: Application ID
+* Password: Application Access Key
 
 ## Uplink Messages
 


### PR DESCRIPTION
I'd like to source https://github.com/TheThingsNetwork/docs/blob/master/_archives/refactor/mqtt/_api.md directly from the README in the ttn repo and made some small modifications for that to work.