### PR TITLE
Feature/xdg

### DIFF
--- a/ttnctl/cmd/applications_add.go
+++ b/ttnctl/cmd/applications_add.go
@@ -49,13 +49,7 @@ var applicationsAddCmd = &cobra.Command{
 
 		skipSelect, _ := cmd.Flags().GetBool("skip-select")
 		if !skipSelect {
-			err = util.SetConfig(map[string]interface{}{
-				"app-id":  app.ID,
-				"app-eui": app.EUIs[0].String(),
-			})
-			if err != nil {
-				ctx.WithError(err).Fatal("Could not update configuration")
-			}
+			util.SetApp(ctx, app.ID, app.EUIs[0])
 		}
 
 		ctx.Info("Selected Current Application")

--- a/ttnctl/cmd/applications_select.go
+++ b/ttnctl/cmd/applications_select.go
@@ -92,16 +92,9 @@ var applicationsSelectCmd = &cobra.Command{
 		}
 		eui := app.EUIs[euiIdx]
 
-		err = util.SetConfig(map[string]interface{}{
-			"app-id":  app.ID,
-			"app-eui": eui.String(),
-		})
-		if err != nil {
-			ctx.WithError(err).Fatal("Could not update configuration")
-		}
+		util.SetApp(ctx, app.ID, eui)
 
 		ctx.Info("Updated configuration")
-
 	},
 }
 

--- a/ttnctl/cmd/devices.go
+++ b/ttnctl/cmd/devices.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"github.com/TheThingsNetwork/ttn/ttnctl/util"
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -16,8 +17,8 @@ var devicesCmd = &cobra.Command{
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		RootCmd.PersistentPreRun(cmd, args)
 		ctx.WithFields(log.Fields{
-			"AppID":  viper.GetString("app-id"),
-			"AppEUI": viper.GetString("app-eui"),
+			"AppID":  util.GetAppID(ctx),
+			"AppEUI": util.GetAppEUI(ctx),
 		}).Info("Using Application")
 	},
 }

--- a/ttnctl/cmd/root.go
+++ b/ttnctl/cmd/root.go
@@ -133,10 +133,10 @@ func initConfig() {
 	viper.AutomaticEnv()
 
 	// If a config file is found, read it in.
-	err := viper.ReadInConfig()
-	if err != nil {
-		fmt.Println("Error when reading config file:", err)
-	} else if err == nil && viper.GetBool("debug") {
-		fmt.Println("Using config file:", viper.ConfigFileUsed())
+	if _, err := os.Stat(cfgFile); err == nil {
+		err := viper.ReadInConfig()
+		if err != nil {
+			fmt.Println("Error when reading config file:", err)
+		}
 	}
 }

--- a/ttnctl/cmd/root.go
+++ b/ttnctl/cmd/root.go
@@ -34,13 +34,16 @@ var RootCmd = &cobra.Command{
 	Long:  `ttnctl controls The Things Network from the command line.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		var logLevel = log.InfoLevel
-		if viper.GetBool("debug") {
+		if debug {
 			logLevel = log.DebugLevel
 		}
 		ctx = &log.Logger{
 			Level:   logLevel,
 			Handler: cliHandler.New(os.Stdout),
 		}
+
+		ctx.WithField("config file", viper.ConfigFileUsed()).WithField("data dir", dataDir).Debug("Using config")
+
 		api.DialOptions = append(api.DialOptions, grpc.WithBlock())
 		api.DialOptions = append(api.DialOptions, grpc.WithTimeout(2*time.Second))
 		grpclog.SetLogger(logging.NewGRPCLogger(ctx))

--- a/ttnctl/cmd/root.go
+++ b/ttnctl/cmd/root.go
@@ -64,8 +64,10 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.ttnctl.yaml)")
-	RootCmd.PersistentFlags().StringVar(&dataDir, "data", "", "directory where ttnctl stores data (default is $HOME/.ttnctl)")
 	RootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "Enable debug mode")
+
+	RootCmd.PersistentFlags().StringVar(&dataDir, "data", "", "directory where ttnctl stores data (default is $HOME/.ttnctl)")
+	viper.BindPFlag("data", RootCmd.PersistentFlags().Lookup("data"))
 
 	RootCmd.PersistentFlags().String("discovery-server", "discover.thethingsnetwork.org:1900", "The address of the Discovery server")
 	viper.BindPFlag("discovery-server", RootCmd.PersistentFlags().Lookup("discovery-server"))
@@ -81,7 +83,6 @@ func init() {
 
 	RootCmd.PersistentFlags().String("ttn-account-server", "https://account.thethingsnetwork.org", "The address of the OAuth 2.0 server")
 	viper.BindPFlag("ttn-account-server", RootCmd.PersistentFlags().Lookup("ttn-account-server"))
-
 }
 
 func printKV(key, t interface{}) {

--- a/ttnctl/util/account.go
+++ b/ttnctl/util/account.go
@@ -44,7 +44,7 @@ func tokenFilename(name string) string {
 
 // GetCache get's the cache that will store our tokens
 func GetTokenCache() cache.Cache {
-	return cache.FileCacheWithNameFn(viper.GetString("token-dir"), tokenFilename)
+	return cache.FileCacheWithNameFn(GetDataDir(), tokenFilename)
 }
 
 func getAccountServerTokenSource(token *oauth2.Token) oauth2.TokenSource {
@@ -120,7 +120,7 @@ func GetTokenSource(ctx log.Interface) oauth2.TokenSource {
 
 func GetTokenManager(accessToken string) tokens.Manager {
 	server := viper.GetString("ttn-account-server")
-	return tokens.HTTPManager(server, accessToken, tokens.FileStore(path.Join(viper.GetString("token-dir"), derivedTokenFile())))
+	return tokens.HTTPManager(server, accessToken, tokens.FileStore(path.Join(GetDataDir(), derivedTokenFile())))
 }
 
 // GetAccount gets a new Account server client for ttnctl

--- a/ttnctl/util/config.go
+++ b/ttnctl/util/config.go
@@ -6,6 +6,7 @@ package util
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path"
 
 	"github.com/TheThingsNetwork/ttn/core/types"
@@ -104,4 +105,49 @@ func GetAppID(ctx log.Interface) string {
 		ctx.Fatal("Missing AppID. You should select an application to use with \"ttnctl applications select\"")
 	}
 	return appID
+}
+
+// GetConfigFile returns the location of the configuration file.
+// It checks the following (in this order):
+// the --config flag
+// $XDG_CONFIG_HOME/ttnctl/config.yml (if $XDG_CONFIG_HOME is set)
+// $HOME/.ttnctl.yml
+func GetConfigFile() string {
+	file := viper.GetString("config")
+	if file != "" {
+		return file
+	}
+
+	xdg := os.Getenv("XDG_CONFIG_HOME")
+	if xdg != "" {
+		return path.Join(xdg, "ttnctl", "config.yml")
+	}
+
+	return path.Join(os.Getenv("HOME"), ".ttnctl.yml")
+}
+
+// GetDataDir returns the location of the data directory used for
+// sotring data.
+// It checks the following (in this order):
+// the --data flag
+// $XDG_DATA_HOME/ttnctl (if $XDG_DATA_HOME is set)
+// $XDG_CACHE_HOME/ttnctl (if $XDG_CACHE_HOME is set)
+// $HOME/.ttnctl
+func GetDataDir() string {
+	file := viper.GetString("data")
+	if file != "" {
+		return file
+	}
+
+	xdg := os.Getenv("XDG_DATA_HOME")
+	if xdg != "" {
+		return path.Join(xdg, "ttnctl")
+	}
+
+	xdg = os.Getenv("XDG_CACHE_HOME")
+	if xdg != "" {
+		return path.Join(xdg, "ttnctl")
+	}
+
+	return path.Join(os.Getenv("HOME"), ".ttnctl")
 }

--- a/ttnctl/util/config.go
+++ b/ttnctl/util/config.go
@@ -9,103 +9,18 @@ import (
 	"os"
 	"path"
 
+	yaml "gopkg.in/yaml.v2"
+
 	"github.com/TheThingsNetwork/ttn/core/types"
 	"github.com/apex/log"
-	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
-	"gopkg.in/yaml.v2"
 )
 
-func getConfigLocation() (string, error) {
-	cFile := viper.ConfigFileUsed()
-	if cFile == "" {
-		dir, err := homedir.Dir()
-		if err != nil {
-			return "", fmt.Errorf("Could not get homedir: %s", err.Error())
-		}
-		expanded, err := homedir.Expand(dir)
-		if err != nil {
-			return "", fmt.Errorf("Could not get homedir: %s", err.Error())
-		}
-		cFile = path.Join(expanded, ".ttnctl.yaml")
-	}
-	return cFile, nil
-}
-
-// ReadConfig reads the config file
-func ReadConfig() (map[string]interface{}, error) {
-	cFile, err := getConfigLocation()
-	if err != nil {
-		return nil, err
-	}
-
-	c := make(map[string]interface{})
-
-	// Read config file
-	bytes, err := ioutil.ReadFile(cFile)
-	if err == nil {
-		err = yaml.Unmarshal(bytes, &c)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("Could not read configuration file: %s", err.Error())
-	}
-
-	return c, nil
-}
-
-// WriteConfigFile writes the config file
-func WriteConfigFile(data map[string]interface{}) error {
-	cFile, err := getConfigLocation()
-	if err != nil {
-		return err
-	}
-
-	// Write config file
-	d, err := yaml.Marshal(&data)
-	if err != nil {
-		return fmt.Errorf("Could not generate configiguration file contents: %s", err.Error())
-	}
-	err = ioutil.WriteFile(cFile, d, 0644)
-	if err != nil {
-		return fmt.Errorf("Could not write configiguration file: %s", err.Error())
-	}
-
-	return nil
-}
-
-// SetConfig sets the specified fields in the config file.
-func SetConfig(data map[string]interface{}) error {
-	config, err := ReadConfig()
-	if err != nil {
-		return err
-	}
-	for key, value := range data {
-		config[key] = value
-	}
-	return WriteConfigFile(config)
-}
-
-// GetAppEUI returns the AppEUI that must be set in the command options or config
-func GetAppEUI(ctx log.Interface) types.AppEUI {
-	appEUIString := viper.GetString("app-eui")
-	if appEUIString == "" {
-		ctx.Fatal("Missing AppEUI. You should select an application to use with \"ttnctl applications select\"")
-	}
-	eui, err := types.ParseAppEUI(appEUIString)
-	if err != nil {
-		ctx.WithError(err).Fatal("Invalid AppEUI")
-	}
-	return eui
-}
-
-// GetAppID returns the AppID that must be set in the command options or config
-func GetAppID(ctx log.Interface) string {
-	appID := viper.GetString("app-id")
-	if appID == "" {
-		ctx.Fatal("Missing AppID. You should select an application to use with \"ttnctl applications select\"")
-	}
-	return appID
-}
+const (
+	appFilename = "app"
+	euiKey      = "eui"
+	idKey       = "id"
+)
 
 // GetConfigFile returns the location of the configuration file.
 // It checks the following (in this order):
@@ -150,4 +65,107 @@ func GetDataDir() string {
 	}
 
 	return path.Join(os.Getenv("HOME"), ".ttnctl")
+}
+
+func readData(file string) map[string]interface{} {
+	fullpath := path.Join(GetDataDir(), file)
+
+	c := make(map[string]interface{})
+
+	// Read config file
+	data, err := ioutil.ReadFile(fullpath)
+	if err != nil {
+		return c
+	}
+
+	err = yaml.Unmarshal(data, &c)
+	if err != nil {
+		return c
+	}
+
+	return c
+}
+
+func writeData(file string, data map[string]interface{}) error {
+	fullpath := path.Join(GetDataDir(), file)
+
+	// Generate yaml contents
+	d, err := yaml.Marshal(&data)
+	if err != nil {
+		return fmt.Errorf("Could not generate configiguration file contents: %s", err.Error())
+	}
+
+	// Write to file
+	err = ioutil.WriteFile(fullpath, d, 0644)
+	if err != nil {
+		return fmt.Errorf("Could not write configuration file: %s", err.Error())
+	}
+
+	return nil
+}
+
+func setData(file, key string, data interface{}) error {
+	config := readData(file)
+	config[key] = data
+	return writeData(file, config)
+}
+
+// GetAppEUI returns the AppEUI that must be set in the command options or config
+func GetAppEUI(ctx log.Interface) types.AppEUI {
+	appEUIString := viper.GetString("app-eui")
+	if appEUIString == "" {
+		appData := readData(appFilename)
+		eui, ok := appData[euiKey].(string)
+		if !ok {
+			ctx.Fatal("Invalid AppEUI in config file")
+		}
+		appEUIString = eui
+	}
+
+	if appEUIString == "" {
+		ctx.Fatal("Missing AppEUI. You should select an application to use with \"ttnctl applications select\"")
+	}
+
+	eui, err := types.ParseAppEUI(appEUIString)
+	if err != nil {
+		ctx.WithError(err).Fatal("Invalid AppEUI")
+	}
+	return eui
+}
+
+// SetApp stores the app EUI preference
+func SetAppEUI(ctx log.Interface, appEUI types.AppEUI) {
+	err := setData(appFilename, euiKey, appEUI.String())
+	if err != nil {
+		ctx.WithError(err).Fatal("Could not save app EUI")
+	}
+}
+
+// GetAppID returns the AppID that must be set in the command options or config
+func GetAppID(ctx log.Interface) string {
+	appID := viper.GetString("app-id")
+	if appID == "" {
+		appData := readData(appFilename)
+		id, ok := appData[idKey].(string)
+		if !ok {
+			ctx.Fatal("Invalid appID in config file.")
+		}
+		appID = id
+	}
+
+	if appID == "" {
+		ctx.Fatal("Missing AppID. You should select an application to use with \"ttnctl applications select\"")
+	}
+	return appID
+}
+
+// SetApp stores the app ID and app EUI preferences
+func SetApp(ctx log.Interface, appID string, appEUI types.AppEUI) {
+	config := readData(appFilename)
+	config[idKey] = appID
+	config[euiKey] = appEUI.String()
+	err := writeData(appFilename, config)
+	if err != nil {
+		ctx.WithError(err).Fatal("Could not save app preference")
+	}
 }


### PR DESCRIPTION
Fixes #210.

The location of the config file is now looked up in this order:
1. `--config` flag
2.`$XDG_CONFIG_HOME/ttnctl/config.yml`
3. `$HOME/.ttnctl.yml`

Similarly, the directory for storing data is inferred as follows:
1. `--data` flag
2.`$XDG_DATA_HOME/ttnctl`
3.`$XDG_CACHE_HOME/ttnctl`
4. `$HOME/.ttnctl`

Furthermore, `ttnctl` no longer writes data to the config file (for instance to store app ID an EUI preferences), but writes preferences to the data directory.

