### PR TITLE
utils/scramble: scramble package

### DIFF
--- a/api/gateway/scramble.go
+++ b/api/gateway/scramble.go
@@ -1,0 +1,16 @@
+package gateway
+
+import "github.com/TheThingsNetwork/ttn/utils/scramble"
+
+func (m *GPSMetadata) Scramble() (err error) {
+	if m.Latitude, err = scramble.Float32(m.Latitude, 10+.01*m.Latitude); err != nil {
+		return err
+	}
+	if m.Longitude, err = scramble.Float32(m.Longitude, 10+.01*m.Longitude); err != nil {
+		return err
+	}
+	if m.Altitude, err = scramble.Int32Delta64(m.Altitude, int64(10+m.Altitude/100)); err != nil {
+		return err
+	}
+	return nil
+}

--- a/utils/scramble/scramble.go
+++ b/utils/scramble/scramble.go
@@ -1,0 +1,67 @@
+package scramble
+
+import (
+	"crypto/rand"
+	"math/big"
+)
+
+func BigInt(val, delta *big.Int) (newVal *big.Int, err error) {
+	var diff *big.Int
+	if diff, err = rand.Int(rand.Reader, delta); err != nil {
+		return nil, err
+	}
+
+	if diff.Bit(0) == 0 {
+		return diff.Add(val, diff), nil
+	} else {
+		return diff.Sub(val, diff), nil
+	}
+}
+
+func Float64(val float64, delta float32) (newVal float64, err error) {
+	var ret float32
+	if ret, err = Float32(float32(val), delta); err != nil {
+		return 0, err
+	}
+	return float64(ret), nil
+}
+
+func Float32(val float32, delta float32) (newVal float32, err error) {
+	const div = 1000
+
+	var res int64
+	if res, err = Int64(int64(div*val), int64(div*delta)); err != nil {
+		return 0, err
+	}
+	return float32(res) / div, nil
+}
+
+func Int64(val, delta int64) (newVal int64, err error) {
+	var ret *big.Int
+	if ret, err = BigInt(big.NewInt(val), big.NewInt(delta)); err != nil {
+		return 0, err
+	}
+	return ret.Int64(), nil
+}
+
+func Int32(val, delta int32) (newVal int32, err error) {
+	return Int32Delta64(val, int64(delta))
+}
+func Int32Delta64(val int32, delta int64) (newVal int32, err error) {
+	var ret *big.Int
+	if ret, err = BigInt(big.NewInt(int64(val)), big.NewInt(delta)); err != nil {
+		return 0, err
+	}
+	return int32(ret.Int64()), nil
+}
+
+func Int(val, delta int) (newVal int, err error) {
+	return IntDelta64(val, int64(delta))
+}
+func IntDelta64(val int, delta int64) (newVal int, err error) {
+	var ret *big.Int
+	if ret, err = BigInt(big.NewInt(int64(val)), big.NewInt(delta)); err != nil {
+		return 0, err
+	}
+	return int(ret.Int64()), nil
+}

--- a/utils/scramble/scramble_test.go
+++ b/utils/scramble/scramble_test.go
@@ -1,0 +1,57 @@
+package scramble
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/assertions"
+)
+
+func TestFloat32(t *testing.T) {
+	a := New(t)
+
+	var val, delta float32 = 13.234567, 1.54123
+
+	newVal, err := Float32(val, delta)
+	a.So(err, ShouldBeNil)
+	a.So(newVal, ShouldBeBetween, val-delta, val+delta)
+}
+
+func TestFloat64(t *testing.T) {
+	a := New(t)
+
+	var val, delta float64 = 13.234567, 1.54123
+
+	newVal, err := Float64(val, float32(delta))
+	a.So(err, ShouldBeNil)
+	a.So(newVal, ShouldBeBetween, val-delta, val+delta)
+}
+
+func TestInt(t *testing.T) {
+	a := New(t)
+
+	var val, delta int = 1234, 13
+
+	newVal, err := Int(val, delta)
+	a.So(err, ShouldBeNil)
+	a.So(newVal, ShouldBeBetween, val-delta, val+delta)
+}
+
+func TestInt32(t *testing.T) {
+	a := New(t)
+
+	var val, delta int32 = 1234, 13
+
+	newVal, err := Int32(val, delta)
+	a.So(err, ShouldBeNil)
+	a.So(newVal, ShouldBeBetween, val-delta, val+delta)
+}
+
+func TestInt64(t *testing.T) {
+	a := New(t)
+
+	var val, delta int64 = 1234, 13
+
+	newVal, err := Int64(val, delta)
+	a.So(err, ShouldBeNil)
+	a.So(newVal, ShouldBeBetween, val-delta, val+delta)
+}


### PR DESCRIPTION
scramble package provides various scrambling functions.
Is uses [crypto/rand] (https://golang.org/pkg/crypto/rand/) for random number generation.
used, for example, by the NOC - if users token does not grant access to gateway location, it gets scrambled, such that the real location does not get reported.

- [ ] A proper `delta` value should be determined for the gateway location field scrambling. What are your opinions?