### PR TITLE
ttnctl/util.GetConfigFile: check if config exists

### DIFF
--- a/ttnctl/util/config.go
+++ b/ttnctl/util/config.go
@@ -28,17 +28,31 @@ const (
 // $XDG_CONFIG_HOME/ttnctl/config.yml (if $XDG_CONFIG_HOME is set)
 // $HOME/.ttnctl.yml
 func GetConfigFile() string {
-	file := viper.GetString("config")
-	if file != "" {
-		return file
-	}
+	flag := viper.GetString("config")
 
 	xdg := os.Getenv("XDG_CONFIG_HOME")
 	if xdg != "" {
-		return path.Join(xdg, "ttnctl", "config.yml")
+		xdg = path.Join(xdg, "ttnctl", "config.yml")
 	}
 
-	return path.Join(os.Getenv("HOME"), ".ttnctl.yml")
+	home := os.Getenv("HOME")
+	if home != "" {
+		home = path.Join(home, ".ttnctl.yml")
+	}
+
+	for _, file := range []string{
+		flag,
+		xdg,
+		home,
+	} {
+		if len(file) > 0 {
+			if _, err := os.Open(file); !os.IsNotExist(err) {
+				return file
+			}
+		}
+	}
+
+	return ""
 }
 
 // GetDataDir returns the location of the data directory used for

--- a/ttnctl/util/config.go
+++ b/ttnctl/util/config.go
@@ -45,8 +45,8 @@ func GetConfigFile() string {
 		xdg,
 		home,
 	} {
-		if len(file) > 0 {
-			if _, err := os.Open(file); !os.IsNotExist(err) {
+		if file != "" {
+			if _, err := os.Stat(file); err == nil {
 				return file
 			}
 		}


### PR DESCRIPTION
this prevents situations, when the variable is defined(or, for example, config flag is set), config file does not exist, but still is used. This PR makes sure `ttnctl` fallsback to other options for the config file and proper value is shown.

consider
```
1 b1101@atom ~ (git)-[atom] % ls ~/.config/ttn*                                                                                                                                                                                                                                                                                                                                                                                       
/home/b1101/.config/ttn-bridge.json
b1101@atom ~ (git)-[atom] % ttnctl -d user login XXX
 DEBUG Using config                             config file=/home/b1101/.config/ttnctl/config.yml data dir=/home/b1101/.local/share/ttnctl
```