### PR TITLE
Fix ttnctl user logout cmd file location

### DIFF
--- a/ttnctl/cmd/user_logout.go
+++ b/ttnctl/cmd/user_logout.go
@@ -4,6 +4,8 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/TheThingsNetwork/ttn/ttnctl/util"
 	"github.com/spf13/cobra"
 )
@@ -15,6 +17,10 @@ var userLogoutCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		err := util.Logout()
 		if err != nil {
+			if os.IsNotExist(err) {
+				ctx.Info("You were not logged in")
+				return
+			}
 			ctx.WithError(err).Fatal("Could not delete credentials")
 		}
 	},

--- a/ttnctl/util/account.go
+++ b/ttnctl/util/account.go
@@ -162,12 +162,12 @@ func TokenForScope(ctx log.Interface, scope string) string {
 }
 
 func Logout() error {
-	err := os.Remove(path.Join(viper.GetString("token-dir"), tokenFile()))
+	err := os.Remove(path.Join(GetDataDir(), tokenFile()))
 	if err != nil {
 		return err
 	}
 
-	err = os.Remove(path.Join(viper.GetString("token-dir"), derivedTokenFile()))
+	err = os.Remove(path.Join(GetDataDir(), derivedTokenFile()))
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}


### PR DESCRIPTION
Fixes `ttnctl user logout`, it tried to remove a file that doesn't exist.