### PR TITLE
Feature/ttnctl config

### DIFF
--- a/ttnctl/cmd/config.go
+++ b/ttnctl/cmd/config.go
@@ -1,0 +1,22 @@
+// Copyright © 2016 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package cmd
+
+import (
+	"github.com/TheThingsNetwork/ttn/ttnctl/util"
+	"github.com/spf13/cobra"
+)
+
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Print the used configuration",
+	Long:  `ttnctl config prints the configuration that is used`,
+	Run: func(cmd *cobra.Command, args []string) {
+		util.PrintConfig(ctx, false)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(configCmd)
+}

--- a/ttnctl/cmd/root.go
+++ b/ttnctl/cmd/root.go
@@ -41,7 +41,9 @@ var RootCmd = &cobra.Command{
 			Handler: cliHandler.New(os.Stdout),
 		}
 
-		ctx.WithField("config file", viper.ConfigFileUsed()).WithField("data dir", dataDir).Debug("Using config")
+		if debug {
+			util.PrintConfig(ctx, true)
+		}
 
 		api.DialOptions = append(api.DialOptions, grpc.WithBlock())
 		api.DialOptions = append(api.DialOptions, grpc.WithTimeout(2*time.Second))

--- a/ttnctl/util/print_config.go
+++ b/ttnctl/util/print_config.go
@@ -1,0 +1,44 @@
+// Copyright © 2016 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package util
+
+import (
+	"fmt"
+
+	"github.com/apex/log"
+	"github.com/spf13/viper"
+)
+
+func PrintConfig(ctx log.Interface, debug bool) {
+	prt := ctx.Infof
+	if debug {
+		prt = ctx.Debugf
+	}
+
+	prt("Using config:")
+	fmt.Println()
+	printKV("config file", viper.ConfigFileUsed())
+	printKV("data dir", viper.GetString("data"))
+	fmt.Println()
+
+	for key, val := range viper.AllSettings() {
+		switch key {
+		case "builddate":
+			fallthrough
+		case "gitcommit":
+			fallthrough
+		case "gitbranch":
+			fallthrough
+		case "version":
+			continue
+		default:
+			printKV(key, val)
+		}
+	}
+	fmt.Println()
+}
+
+func printKV(key, val interface{}) {
+	fmt.Printf("%20s: %s\n", key, val)
+}


### PR DESCRIPTION
Adds the `ttnctl config` command that prints the config variables and also prints them when the `-d` flag is present.