### PR TITLE
Use %v instead of %s in print_config

### DIFF
--- a/ttnctl/util/print_config.go
+++ b/ttnctl/util/print_config.go
@@ -40,5 +40,5 @@ func PrintConfig(ctx log.Interface, debug bool) {
 }
 
 func printKV(key, val interface{}) {
-	fmt.Printf("%20s: %s\n", key, val)
+	fmt.Printf("%20s: %v\n", key, val)
 }


### PR DESCRIPTION
We need to use `%v` to print values of the config files instead of using `%s` (in `ttn/ttnctl/util/print_config.go`which is dedicated only for displaying strings. If we have integers as value in the config file, the we have something like:
`server-address:localhost server-port:%!s(int=8887)`.