### PR TITLE
Linking the NuGet download for Redis which works on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ When you get started with The Things Network, you'll probably have some question
 1. Make sure you have [Go](https://golang.org) installed (version 1.7 or later).
 2. Set up your [Go environment](https://golang.org/doc/code.html#GOPATH)
 3. Install the [protobuf compiler (`protoc`)](https://github.com/google/protobuf/releases)
-4. Make sure you have [Redis](http://redis.io/download) and [RabbitMQ](https://www.rabbitmq.com/download.html) **installed** and **running**.  
+4. Make sure you have [Redis](http://redis.io/download) or [Redis from NuGet for Windows](https://www.nuget.org/packages/Redis-64/) and [RabbitMQ](https://www.rabbitmq.com/download.html) **installed** and **running**.  
   On a fresh installation you might need to install the [MQTT plugin](https://www.rabbitmq.com/mqtt.html).  
   If you're on Linux, you probably know how to do that. On a Mac, just run `brew bundle`. The Windows installer will setup and start RabbitMQ as a service. Use the `RabbitMQ Command Prompt (sbin dir)` to run commands, i.e. to enable plugins.
 5. Declare a RabbitMQ exchange `ttn.handler` of type `topic`. Using [the management plugin](http://www.rabbitmq.com/management.html), declare the exchange in the web interface `http://server-name:15672` or using the management cli, run `rabbitmqadmin declare exchange name=ttn.handler type=topic auto_delete=false durable=true`


### PR DESCRIPTION
Actually windows user can use NuGet or Chocolatey to install Redis. The port is supported by MSOpenTech and provides the most recent builds I found. Imho NuGet is the easier way to install, since I failed once on Chocolatey ;)