### PR TITLE
utils/errors.FromGRPCError: io.EOF, fix unknown

### DIFF
--- a/utils/errors/errors.go
+++ b/utils/errors/errors.go
@@ -2,6 +2,7 @@ package errors
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"google.golang.org/grpc"
@@ -83,7 +84,10 @@ func FromGRPCError(err error) error {
 	case codes.PermissionDenied:
 		return NewErrPermissionDenied(strings.TrimPrefix(desc, "permission denied: "))
 	case codes.Unknown: // This also includes all non-gRPC errors
-		return errs.New(err.Error())
+		if desc == "EOF" {
+			return io.EOF
+		}
+		return errs.New(desc)
 	}
 	return NewErrInternal(fmt.Sprintf("[%s] %s", code, desc))
 }


### PR DESCRIPTION
`errors.FromGRPCError` currently returns 'rpc error: code = 2 desc = EOF' on io.EOF wrapped by `BuildGRPCError` (for example when sending on a closed stream), this PR fixes that and makes errors with 'unknown' grpc code human-readable. 