### PR TITLE
v2.0.1

### DIFF
--- a/.env/broker/dev.yml
+++ b/.env/broker/dev.yml
@@ -2,8 +2,7 @@ id: dev
 debug: true
 discovery-address: "localhost:1900"
 auth-servers:
-  ttn-account: "https://account.thethingsnetwork.org"
-  ttn-account-preview: "https://preview.account.thethingsnetwork.org"
+  ttn-account-v2: "https://account.thethingsnetwork.org"
 tls: true
 key-dir: "./.env/broker/"
 

--- a/.env/discovery/dev.yml
+++ b/.env/discovery/dev.yml
@@ -2,6 +2,5 @@ id: dev
 debug: true
 discovery-address: "localhost:1900"
 auth-servers:
-  ttn-account: "https://account.thethingsnetwork.org"
-  ttn-account-preview: "https://preview.account.thethingsnetwork.org"
+  ttn-account-v2: "https://account.thethingsnetwork.org"
 key-dir: "./.env/discovery/"

--- a/.env/handler/dev.yml
+++ b/.env/handler/dev.yml
@@ -2,8 +2,7 @@ id: dev
 debug: true
 discovery-address: "localhost:1900"
 auth-servers:
-  ttn-account: "https://account.thethingsnetwork.org"
-  ttn-account-preview: "https://preview.account.thethingsnetwork.org"
+  ttn-account-v2: "https://account.thethingsnetwork.org"
 tls: true
 key-dir: "./.env/handler/"
 handler:

--- a/.env/networkserver/dev.yml
+++ b/.env/networkserver/dev.yml
@@ -1,7 +1,6 @@
 debug: true
 discovery-address: "localhost:1900"
 auth-servers:
-  ttn-account: "https://account.thethingsnetwork.org"
-  ttn-account-preview: "https://preview.account.thethingsnetwork.org"
+  ttn-account-v2: "https://account.thethingsnetwork.org"
 tls: true
 key-dir: "./.env/networkserver/"

--- a/.env/router/dev.yml
+++ b/.env/router/dev.yml
@@ -2,8 +2,7 @@ id: dev
 debug: true
 discovery-address: "localhost:1900"
 auth-servers:
-  ttn-account: "https://account.thethingsnetwork.org"
-  ttn-account-preview: "https://preview.account.thethingsnetwork.org"
+  ttn-account-v2: "https://account.thethingsnetwork.org"
 tls: true
 key-dir: "./.env/router/"
 router:

--- a/Makefile
+++ b/Makefile
@@ -112,8 +112,10 @@ CGO_ENABLED ?= 0
 
 ifeq ($(GIT_BRANCH), $(GIT_TAG))
 	TTN_VERSION = $(GIT_TAG)
+	TAGS += prod
 else
 	TTN_VERSION = $(GIT_TAG)-dev
+	TAGS += dev
 endif
 
 DIST_FLAGS ?= -a -installsuffix cgo

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ When you get started with The Things Network, you'll probably have some question
 ## Set up The Things Network's backend for Development
 
 1. Fork this repository
-2. Clone your fork: `git clone https://github.com/YOURUSERNAME/ttn.git $GOPATH/src/github.com/TheThingsNetwork/ttn`
+2. Clone your fork: `git clone --branch develop https://github.com/YOURUSERNAME/ttn.git $GOPATH/src/github.com/TheThingsNetwork/ttn`
 3. `cd $GOPATH/src/github.com/TheThingsNetwork/ttn`
 4. Install the dependencies for development: `make dev-deps`
 5. Run the tests: `make test`

--- a/api/discovery/client.go
+++ b/api/discovery/client.go
@@ -53,7 +53,7 @@ func NewClient(server string, announcement *Announcement, tokenFunc func() strin
 	client.cache = gcache.
 		New(CacheSize).
 		Expiration(CacheExpiration).
-		ARC().
+		LRU().
 		LoaderFunc(func(k interface{}) (interface{}, error) {
 			key, ok := k.(cacheKey)
 			if !ok {

--- a/cmd/discovery.go
+++ b/cmd/discovery.go
@@ -125,7 +125,7 @@ func init() {
 	discoveryCmd.Flags().Bool("cache", false, "Add a cache in front of the database")
 	viper.BindPFlag("discovery.cache", discoveryCmd.Flags().Lookup("cache"))
 
-	discoveryCmd.Flags().StringSlice("master-auth-servers", []string{"ttn-account"}, "Auth servers that are allowed to manage this network")
+	discoveryCmd.Flags().StringSlice("master-auth-servers", []string{"ttn-account-v2"}, "Auth servers that are allowed to manage this network")
 	viper.BindPFlag("discovery.master-auth-servers", discoveryCmd.Flags().Lookup("master-auth-servers"))
 
 	discoveryCmd.Flags().String("http-address", "0.0.0.0", "The IP address where the gRPC proxy should listen")

--- a/cmd/docs/README.md
+++ b/cmd/docs/README.md
@@ -68,7 +68,7 @@ ttn broker register prefix registers a prefix to this Broker
       --cache                             Add a cache in front of the database
       --http-address string               The IP address where the gRPC proxy should listen (default "0.0.0.0")
       --http-port int                     The port where the gRPC proxy should listen (default 8080)
-      --master-auth-servers stringSlice   Auth servers that are allowed to manage this network (default [ttn-account])
+      --master-auth-servers stringSlice   Auth servers that are allowed to manage this network (default [ttn-account-v2])
       --redis-address string              Redis server and port (default "localhost:6379")
       --redis-db int                      Redis database
       --server-address string             The IP address to listen for communication (default "0.0.0.0")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -138,7 +138,7 @@ func init() {
 	RootCmd.PersistentFlags().Int("health-port", 0, "The port number where the health server should be started")
 
 	viper.SetDefault("auth-servers", map[string]string{
-		"ttn-account": "https://account.thethingsnetwork.org",
+		"ttn-account-v2": "https://account.thethingsnetwork.org",
 	})
 
 	dir, err := homedir.Dir()

--- a/core/component/pprof.go
+++ b/core/component/pprof.go
@@ -1,4 +1,4 @@
-// +build pprof
+// +build dev
 
 // Copyright © 2016 The Things Network
 // Use of this source code is governed by the MIT license that can be found in the LICENSE file.

--- a/core/discovery/announcement/cache.go
+++ b/core/discovery/announcement/cache.go
@@ -40,13 +40,13 @@ func serviceCacheKey(serviceName, serviceID string) string {
 
 // NewCachedAnnouncementStore returns a cache wrapper around the existing store
 func NewCachedAnnouncementStore(store Store, options CacheOptions) Store {
-	serviceCache := gcache.New(options.ServiceCacheSize).Expiration(options.ServiceCacheExpiration).LFU().
+	serviceCache := gcache.New(options.ServiceCacheSize).Expiration(options.ServiceCacheExpiration).LRU().
 		LoaderFunc(func(k interface{}) (interface{}, error) {
 			key := strings.Split(k.(string), ":")
 			return store.Get(key[0], key[1])
 		}).Build()
 
-	listCache := gcache.New(options.ListCacheSize).Expiration(options.ListCacheExpiration).LFU().
+	listCache := gcache.New(options.ListCacheSize).Expiration(options.ListCacheExpiration).LRU().
 		LoaderFunc(func(k interface{}) (interface{}, error) {
 			key := k.(string)
 			announcements, err := store.ListService(key)

--- a/core/handler/convert_fields.go
+++ b/core/handler/convert_fields.go
@@ -189,7 +189,7 @@ type DownlinkFunctions struct {
 // If no encoder function is set, this function returns an array.
 func (f *DownlinkFunctions) Encode(payload map[string]interface{}, port uint8) ([]byte, error) {
 	if f.Encoder == "" {
-		return nil, errors.NewErrInternal("Encoder function not set")
+		return nil, errors.NewErrInvalidArgument("Downlink Payload", "fields supplied, but no Encoder function set")
 	}
 
 	env := map[string]interface{}{
@@ -285,7 +285,7 @@ func (f *DownlinkFunctions) Process(payload map[string]interface{}, port uint8) 
 
 // ConvertFieldsDown converts the fields into a payload
 func (h *handler) ConvertFieldsDown(ctx log.Interface, appDown *types.DownlinkMessage, ttnDown *pb_broker.DownlinkMessage) error {
-	if appDown.PayloadFields == nil {
+	if appDown.PayloadFields == nil || len(appDown.PayloadFields) == 0 {
 		return nil
 	}
 

--- a/ttnctl/cmd/version.go
+++ b/ttnctl/cmd/version.go
@@ -1,3 +1,5 @@
+// +build !homebrew
+
 // Copyright © 2016 The Things Network
 // Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 

--- a/ttnctl/cmd/version_homebrew.go
+++ b/ttnctl/cmd/version_homebrew.go
@@ -1,0 +1,31 @@
+// +build homebrew
+
+// Copyright © 2016 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package cmd
+
+import (
+	"github.com/apex/log"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Get build and version information",
+	Long:  `ttnctl version gets the build and version information of ttnctl`,
+	Run: func(cmd *cobra.Command, args []string) {
+		gitCommit := viper.GetString("gitCommit")
+		buildDate := viper.GetString("buildDate")
+		ctx.WithFields(log.Fields{
+			"Version":   viper.GetString("version") + "-homebrew",
+			"Commit":    gitCommit,
+			"BuildDate": buildDate,
+		}).Info("Got build information")
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
- Small changes in dev env and docs
- Introduce `dev` and `prod` build tags
- Switch to LRU caches (because of nil-pointer panic in ARC cache)
- Improved error if downlink fields supplied, but no encoder set
- Add `ttnctl version` cmd specifically for Homebrew builds