### PR TITLE
Added regex to validation error

### DIFF
--- a/api/validation.go
+++ b/api/validation.go
@@ -4,7 +4,6 @@
 package api
 
 import (
-	"fmt"
 	"reflect"
 	"regexp"
 
@@ -39,7 +38,7 @@ func NotEmptyAndValidID(id string, argument string) error {
 		return errors.NewErrInvalidArgument(argument, "can not be empty")
 	}
 	if !ValidID(id) {
-		return errors.NewErrInvalidArgument(argument, fmt.Sprintf("has wrong format (got '%s' want '%s')", id, idRegexp.String()))
+		return errors.NewErrInvalidArgument(argument, "has wrong format. IDs can contain lowercase letters, numbers, dashes and underscores and should have a maximum length of 36")
 	}
 	return nil
 }

--- a/api/validation.go
+++ b/api/validation.go
@@ -4,6 +4,7 @@
 package api
 
 import (
+	"fmt"
 	"reflect"
 	"regexp"
 
@@ -38,7 +39,7 @@ func NotEmptyAndValidID(id string, argument string) error {
 		return errors.NewErrInvalidArgument(argument, "can not be empty")
 	}
 	if !ValidID(id) {
-		return errors.NewErrInvalidArgument(argument, "has wrong format "+id)
+		return errors.NewErrInvalidArgument(argument, fmt.Sprintf("has wrong format (got '%s' want '%s')", id, idRegexp.String()))
 	}
 	return nil
 }

--- a/api/validation_test.go
+++ b/api/validation_test.go
@@ -85,7 +85,7 @@ func TestNotEmptyAndValidID(t *testing.T) {
 	}
 
 	err = NotEmptyAndValidID("a", "subject")
-	if err == nil || err.Error() != "subject not valid: has wrong format (got 'a' want '^[0-9a-z](?:[_-]?[0-9a-z]){1,35}$')" {
+	if err == nil || err.Error() != "subject not valid: has wrong format. IDs can contain lowercase letters, numbers, dashes and underscores and should have a maximum length of 36" {
 		t.Error("Expected validation error: 'subject not valid: has wrong format a' but found", err)
 	}
 }

--- a/api/validation_test.go
+++ b/api/validation_test.go
@@ -85,7 +85,7 @@ func TestNotEmptyAndValidID(t *testing.T) {
 	}
 
 	err = NotEmptyAndValidID("a", "subject")
-	if err == nil || err.Error() != "subject not valid: has wrong format a" {
+	if err == nil || err.Error() != "subject not valid: has wrong format (got 'a' want '^[0-9a-z](?:[_-]?[0-9a-z]){1,35}$')" {
 		t.Error("Expected validation error: 'subject not valid: has wrong format a' but found", err)
 	}
 }


### PR DESCRIPTION
This PR is a proposal. 
Despite the fact that the format of the regex is proper to golang I would like to add the regex to the error message when a validation is not successful. This is pretty useful for the user when he gets a "Invalid format" error message. 
