### PR TITLE
Fix component startup when a monitor server is down

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,6 +11,7 @@
 Antoine Rondelet <rondelet.antoine@gmail.com>
 Fokke Zandbergen <mail@fokkezb.nl>
 Hylke Visser <htdvisser@gmail.com>
+Jan Kramer <jan@jankramer.eu>
 Johan Stokking <johan@thethingsnetwork.org>
 Matthias Benkort <matthias.benkort@gmail.com>
 Roman Volosatovs <rvolosatovs@riseup.net>

--- a/api/monitor/registry.go
+++ b/api/monitor/registry.go
@@ -1,8 +1,12 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
 package monitor
 
 import (
-	"github.com/apex/log"
 	"sync"
+
+	"github.com/apex/log"
 )
 
 // Registry encapsulates dealing with monitor servers that might be down during startup.

--- a/api/monitor/registry.go
+++ b/api/monitor/registry.go
@@ -1,0 +1,108 @@
+package monitor
+
+import (
+	"github.com/apex/log"
+	"sync"
+)
+
+// Registry encapsulates dealing with monitor servers that might be down during startup.
+type Registry interface {
+	// InitClient initializes a new monitor client.
+	InitClient(name string, addr string)
+
+	// BrokerClients returns the list of broker monitor clients that have currently been initialized.
+	BrokerClients() []BrokerClient
+
+	// GatewayClients returns the list of gateway monitor clients that have currently been initialized for a given gateway.
+	GatewayClients(id string) []GatewayClient
+
+	// SetGatewayToken configures a token that's applied to all clients for a gateway, regardless of when it's initialized.
+	SetGatewayToken(id string, token string)
+}
+
+// NewRegistry creates a monitor client registry.
+func NewRegistry(ctx log.Interface) Registry {
+	return &registry{
+		ctx:              ctx,
+		monitorClients:   make(map[string]*Client),
+		brokerClients:    make([]BrokerClient, 0),
+		gatewayClients:   make(map[string][]GatewayClient, 0),
+		gatewayTokens:    make(map[string]string),
+		newMonitorClient: NewClient, // Add as struct var so it can be stubbed in tests
+	}
+}
+
+type registry struct {
+	ctx              log.Interface
+	monitorClients   map[string]*Client
+	brokerClients    []BrokerClient
+	gatewayClients   map[string][]GatewayClient
+	gatewayTokens    map[string]string
+	newMonitorClient func(ctx log.Interface, addr string) (*Client, error)
+	sync.RWMutex
+}
+
+func (r *registry) InitClient(name string, addr string) {
+	client, err := r.newMonitorClient(r.ctx, addr)
+	if err != nil {
+		r.ctx.WithError(err).Warn("Unable to initialize client")
+		return
+	}
+
+	// Only lock from here, since NewClient blocks when monitor server is down.
+	r.Lock()
+	defer r.Unlock()
+
+	r.monitorClients[name] = client
+	r.brokerClients = append(r.brokerClients, client.BrokerClient)
+
+	// Add gateway client from the new monitor client for every gateway that has been retrieved before.
+	for id := range r.gatewayClients {
+		gwClient := client.GatewayClient(id)
+		gwClient.SetToken(r.gatewayTokens[id])
+		r.gatewayClients[id] = append(r.gatewayClients[id], gwClient)
+	}
+}
+
+func (r *registry) BrokerClients() []BrokerClient {
+	r.RLock()
+	defer r.RUnlock()
+
+	return r.brokerClients
+}
+
+func (r *registry) GatewayClients(id string) []GatewayClient {
+	r.RLock()
+	clients, ok := r.gatewayClients[id]
+	r.RUnlock()
+
+	if ok {
+		return clients
+	}
+
+	r.Lock()
+	defer r.Unlock()
+
+	r.gatewayClients[id] = make([]GatewayClient, 0)
+	for _, client := range r.monitorClients {
+		gwClient := client.GatewayClient(id)
+		gwClient.SetToken(r.gatewayTokens[id])
+		r.gatewayClients[id] = append(r.gatewayClients[id], gwClient)
+	}
+
+	return r.gatewayClients[id]
+}
+
+func (r *registry) SetGatewayToken(id string, token string) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.gatewayTokens[id] = token
+
+	// Update token on existing clients
+	if _, ok := r.gatewayClients[id]; ok {
+		for _, gatewayClient := range r.gatewayClients[id] {
+			gatewayClient.SetToken(token)
+		}
+	}
+}

--- a/api/monitor/registry_test.go
+++ b/api/monitor/registry_test.go
@@ -5,10 +5,11 @@ package monitor
 
 import (
 	"errors"
+	"testing"
+
 	. "github.com/TheThingsNetwork/ttn/utils/testing"
 	"github.com/apex/log"
 	. "github.com/smartystreets/assertions"
-	"testing"
 )
 
 func TestNewRegistry(t *testing.T) {

--- a/api/monitor/registry_test.go
+++ b/api/monitor/registry_test.go
@@ -1,0 +1,152 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package monitor
+
+import (
+	"errors"
+	. "github.com/TheThingsNetwork/ttn/utils/testing"
+	"github.com/apex/log"
+	. "github.com/smartystreets/assertions"
+	"testing"
+)
+
+func TestNewRegistry(t *testing.T) {
+	a := New(t)
+	r := NewRegistry(GetLogger(t, "TestNewRegistry"))
+	a.So(r, ShouldNotBeNil)
+}
+
+func TestInitClient(t *testing.T) {
+	a := New(t)
+	ctx := GetLogger(t, "TestInitClient")
+
+	t.Run("RegistersValidClients", func(t *testing.T) {
+		r := NewRegistry(ctx).(*registry)
+		r.newMonitorClient = returnClient
+
+		r.InitClient("", "")
+
+		a.So(r.monitorClients, ShouldHaveLength, 1)
+	})
+
+	t.Run("HandlesInitError", func(t *testing.T) {
+		r := NewRegistry(ctx).(*registry)
+		r.newMonitorClient = returnError
+
+		r.InitClient("", "")
+
+		a.So(r.monitorClients, ShouldHaveLength, 0)
+	})
+}
+
+func TestBrokerClients(t *testing.T) {
+	a := New(t)
+	r := NewRegistry(GetLogger(t, "TestBrokerClients")).(*registry)
+	r.newMonitorClient = returnClient
+
+	r.InitClient("a", "")
+	r.InitClient("b", "")
+
+	a.So(r.BrokerClients(), ShouldHaveLength, 2)
+}
+
+func TestGatewayClients(t *testing.T) {
+	a := New(t)
+	ctx := GetLogger(t, "TestGatewayClients")
+
+	t.Run("Init", func(t *testing.T) {
+		r := NewRegistry(ctx).(*registry)
+		r.newMonitorClient = returnClient
+
+		r.InitClient("a", "")
+
+		a.So(r.GatewayClients("foo"), ShouldHaveLength, 1)
+	})
+
+	t.Run("GatewayClients -> Init", func(t *testing.T) {
+		r := NewRegistry(ctx).(*registry)
+		r.newMonitorClient = returnClient
+
+		r.GatewayClients("foo")
+		r.InitClient("a", "")
+
+		a.So(r.GatewayClients("foo"), ShouldHaveLength, 1)
+	})
+
+	t.Run("GatewayClients -> Init -> Token", func(t *testing.T) {
+		r := NewRegistry(ctx).(*registry)
+		r.newMonitorClient = returnClient
+
+		r.GatewayClients("foo")
+		r.InitClient("", "")
+		r.SetGatewayToken("foo", "bar")
+
+		a.So(r.GatewayClients("foo")[0].(*gatewayClient).token, ShouldEqual, "bar")
+	})
+
+	t.Run("GatewayClients -> Token -> Init", func(t *testing.T) {
+		r := NewRegistry(ctx).(*registry)
+		r.newMonitorClient = returnClient
+
+		r.GatewayClients("foo")
+		r.SetGatewayToken("foo", "bar")
+		r.InitClient("", "")
+
+		a.So(r.GatewayClients("foo")[0].(*gatewayClient).token, ShouldEqual, "bar")
+	})
+
+	t.Run("Init -> GatewayClients -> Token", func(t *testing.T) {
+		r := NewRegistry(ctx).(*registry)
+		r.newMonitorClient = returnClient
+
+		r.InitClient("", "")
+		r.GatewayClients("foo")
+		r.SetGatewayToken("foo", "bar")
+
+		a.So(r.GatewayClients("foo")[0].(*gatewayClient).token, ShouldEqual, "bar")
+	})
+
+	t.Run("Init -> Token -> GatewayClients", func(t *testing.T) {
+		r := NewRegistry(ctx).(*registry)
+		r.newMonitorClient = returnClient
+
+		r.InitClient("", "")
+		r.SetGatewayToken("foo", "bar")
+
+		a.So(r.GatewayClients("foo")[0].(*gatewayClient).token, ShouldEqual, "bar")
+	})
+
+	t.Run("Token -> GatewayClients -> Init", func(t *testing.T) {
+		r := NewRegistry(ctx).(*registry)
+		r.newMonitorClient = returnClient
+
+		r.SetGatewayToken("foo", "bar")
+		r.GatewayClients("foo")
+		r.InitClient("", "")
+
+		a.So(r.GatewayClients("foo")[0].(*gatewayClient).token, ShouldEqual, "bar")
+	})
+
+	t.Run("Token -> Init -> GatewayClients", func(t *testing.T) {
+		r := NewRegistry(ctx).(*registry)
+		r.newMonitorClient = returnClient
+
+		r.SetGatewayToken("foo", "bar")
+		r.InitClient("a", "")
+
+		a.So(r.GatewayClients("foo")[0].(*gatewayClient).token, ShouldEqual, "bar")
+	})
+}
+
+var returnClient = func(ctx log.Interface, addr string) (*Client, error) {
+	return &Client{
+		Ctx:          ctx,
+		BrokerClient: &brokerClient{},
+		gateways:     make(map[string]GatewayClient),
+	}, nil
+}
+
+var returnError = func(ctx log.Interface, addr string) (*Client, error) {
+	return nil, errors.New("")
+}

--- a/core/broker/broker.go
+++ b/core/broker/broker.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/TheThingsNetwork/ttn/api"
 	pb "github.com/TheThingsNetwork/ttn/api/broker"
-	pb_monitor "github.com/TheThingsNetwork/ttn/api/monitor"
 	"github.com/TheThingsNetwork/ttn/api/networkserver"
 	pb_lorawan "github.com/TheThingsNetwork/ttn/api/protocol/lorawan"
 	"github.com/TheThingsNetwork/ttn/core/component"
@@ -42,8 +41,6 @@ func NewBroker(timeout time.Duration) Broker {
 		handlers:               make(map[string]*handler),
 		uplinkDeduplicator:     NewDeduplicator(timeout),
 		activationDeduplicator: NewDeduplicator(timeout),
-
-		Monitors: make(map[string]pb_monitor.BrokerClient),
 	}
 }
 
@@ -67,8 +64,6 @@ type broker struct {
 	uplinkDeduplicator     Deduplicator
 	activationDeduplicator Deduplicator
 	status                 *status
-
-	Monitors map[string]pb_monitor.BrokerClient
 }
 
 func (b *broker) checkPrefixAnnouncements() error {
@@ -137,9 +132,6 @@ func (b *broker) Init(c *component.Component) error {
 	b.checkPrefixAnnouncements()
 	b.Component.SetStatus(component.StatusHealthy)
 
-	for name, monitor := range b.Component.Monitors {
-		b.Monitors[name] = monitor.BrokerClient
-	}
 	return nil
 }
 

--- a/core/broker/downlink.go
+++ b/core/broker/downlink.go
@@ -33,7 +33,7 @@ func (b *broker) HandleDownlink(downlink *pb.DownlinkMessage) error {
 		} else {
 			ctx.WithField("Duration", time.Now().Sub(start)).Info("Handled downlink")
 		}
-		for _, monitor := range b.Monitors {
+		for _, monitor := range b.Monitors.BrokerClients() {
 			ctx.Debug("Sending downlink to monitor")
 			go monitor.SendDownlink(downlink)
 		}

--- a/core/broker/downlink_test.go
+++ b/core/broker/downlink_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	pb "github.com/TheThingsNetwork/ttn/api/broker"
+	pb_monitor "github.com/TheThingsNetwork/ttn/api/monitor"
 	"github.com/TheThingsNetwork/ttn/core/component"
 	"github.com/TheThingsNetwork/ttn/core/types"
 	. "github.com/TheThingsNetwork/ttn/utils/testing"
@@ -20,10 +21,11 @@ func TestDownlink(t *testing.T) {
 	devEUI := types.DevEUI{0, 1, 2, 3, 4, 5, 6, 7}
 
 	dlch := make(chan *pb.DownlinkMessage, 2)
-
+	logger := GetLogger(t, "TestDownlink")
 	b := &broker{
 		Component: &component.Component{
-			Ctx: GetLogger(t, "TestDownlink"),
+			Ctx:      logger,
+			Monitors: pb_monitor.NewRegistry(logger),
 		},
 		ns: &mockNetworkServer{},
 		routers: map[string]chan *pb.DownlinkMessage{

--- a/core/broker/uplink.go
+++ b/core/broker/uplink.go
@@ -39,7 +39,7 @@ func (b *broker) HandleUplink(uplink *pb.UplinkMessage) (err error) {
 		} else {
 			ctx.WithField("Duration", time.Now().Sub(start)).Info("Handled uplink")
 		}
-		for _, monitor := range b.Monitors {
+		for _, monitor := range b.Monitors.BrokerClients() {
 			ctx.Debug("Sending uplink to monitor")
 			go monitor.SendUplink(deduplicatedUplink)
 		}

--- a/core/broker/util_test.go
+++ b/core/broker/util_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	pb_discovery "github.com/TheThingsNetwork/ttn/api/discovery"
+	"github.com/TheThingsNetwork/ttn/api/monitor"
 	pb_networkserver "github.com/TheThingsNetwork/ttn/api/networkserver"
 	"github.com/TheThingsNetwork/ttn/core/component"
 	. "github.com/TheThingsNetwork/ttn/utils/testing"
@@ -25,11 +26,13 @@ func getTestBroker(t *testing.T) *testBroker {
 	ctrl := gomock.NewController(t)
 	discovery := pb_discovery.NewMockClient(ctrl)
 	ns := pb_networkserver.NewMockNetworkServerClient(ctrl)
+	logger := GetLogger(t, "TestBroker")
 	b := &testBroker{
 		broker: &broker{
 			Component: &component.Component{
 				Discovery: discovery,
-				Ctx:       GetLogger(t, "TestBroker"),
+				Ctx:       logger,
+				Monitors:  monitor.NewRegistry(logger),
 			},
 			handlers:               make(map[string]*handler),
 			activationDeduplicator: NewDeduplicator(10 * time.Millisecond),

--- a/core/router/downlink_test.go
+++ b/core/router/downlink_test.go
@@ -10,6 +10,7 @@ import (
 
 	pb_broker "github.com/TheThingsNetwork/ttn/api/broker"
 	pb_gateway "github.com/TheThingsNetwork/ttn/api/gateway"
+	"github.com/TheThingsNetwork/ttn/api/monitor"
 	pb_protocol "github.com/TheThingsNetwork/ttn/api/protocol"
 	pb_lorawan "github.com/TheThingsNetwork/ttn/api/protocol/lorawan"
 	pb "github.com/TheThingsNetwork/ttn/api/router"
@@ -39,9 +40,11 @@ func newReferenceDownlink() *pb.DownlinkMessage {
 func TestHandleDownlink(t *testing.T) {
 	a := New(t)
 
+	logger := GetLogger(t, "TestHandleDownlink")
 	r := &router{
 		Component: &component.Component{
-			Ctx: GetLogger(t, "TestHandleDownlink"),
+			Ctx:      logger,
+			Monitors: monitor.NewRegistry(logger),
 		},
 		gateways: map[string]*gateway.Gateway{},
 	}
@@ -65,9 +68,11 @@ func TestHandleDownlink(t *testing.T) {
 func TestSubscribeUnsubscribeDownlink(t *testing.T) {
 	a := New(t)
 
+	logger := GetLogger(t, "TestSubscribeUnsubscribeDownlink")
 	r := &router{
 		Component: &component.Component{
-			Ctx: GetLogger(t, "TestSubscribeUnsubscribeDownlink"),
+			Ctx:      logger,
+			Monitors: monitor.NewRegistry(logger),
 		},
 		gateways: map[string]*gateway.Gateway{},
 	}

--- a/core/router/gateway_status_test.go
+++ b/core/router/gateway_status_test.go
@@ -8,6 +8,7 @@ import (
 
 	pb_discovery "github.com/TheThingsNetwork/ttn/api/discovery"
 	pb_gateway "github.com/TheThingsNetwork/ttn/api/gateway"
+	"github.com/TheThingsNetwork/ttn/api/monitor"
 	"github.com/TheThingsNetwork/ttn/core/component"
 	"github.com/TheThingsNetwork/ttn/core/router/gateway"
 	. "github.com/TheThingsNetwork/ttn/utils/testing"
@@ -18,10 +19,12 @@ func TestHandleGatewayStatus(t *testing.T) {
 	a := New(t)
 	gtwID := "eui-0102030405060708"
 
+	logger := GetLogger(t, "TestHandleGatewayStatus")
 	router := &router{
 		Component: &component.Component{
-			Ctx:      GetLogger(t, "TestHandleGatewayStatus"),
+			Ctx:      logger,
 			Identity: &pb_discovery.Announcement{},
+			Monitors: monitor.NewRegistry(logger),
 		},
 		gateways: map[string]*gateway.Gateway{},
 	}

--- a/core/router/router.go
+++ b/core/router/router.go
@@ -12,7 +12,6 @@ import (
 	pb_broker "github.com/TheThingsNetwork/ttn/api/broker"
 	pb_discovery "github.com/TheThingsNetwork/ttn/api/discovery"
 	pb_gateway "github.com/TheThingsNetwork/ttn/api/gateway"
-	pb_monitor "github.com/TheThingsNetwork/ttn/api/monitor"
 	pb "github.com/TheThingsNetwork/ttn/api/router"
 	"github.com/TheThingsNetwork/ttn/core/component"
 	"github.com/TheThingsNetwork/ttn/core/router/gateway"
@@ -120,13 +119,7 @@ func (r *router) getGateway(id string) *gateway.Gateway {
 	gtw, ok = r.gateways[id]
 	if !ok {
 		gtw = gateway.NewGateway(r.Ctx, id)
-
-		if r.Component.Monitors != nil {
-			gtw.Monitors = make(map[string]pb_monitor.GatewayClient)
-			for name, cl := range r.Component.Monitors {
-				gtw.Monitors[name] = cl.GatewayClient(gtw.ID)
-			}
-		}
+		gtw.Monitors = r.Component.Monitors
 
 		r.gateways[id] = gtw
 	}

--- a/core/router/util_test.go
+++ b/core/router/util_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/TheThingsNetwork/ttn/api/discovery"
+	"github.com/TheThingsNetwork/ttn/api/monitor"
 	"github.com/TheThingsNetwork/ttn/core/component"
 	"github.com/TheThingsNetwork/ttn/core/router/gateway"
 	. "github.com/TheThingsNetwork/ttn/utils/testing"
@@ -22,11 +23,13 @@ type testRouter struct {
 func getTestRouter(t *testing.T) *testRouter {
 	ctrl := gomock.NewController(t)
 	discovery := discovery.NewMockClient(ctrl)
+	logger := GetLogger(t, "TestRouter")
 	r := &testRouter{
 		router: &router{
 			Component: &component.Component{
 				Discovery: discovery,
-				Ctx:       GetLogger(t, "TestRouter"),
+				Ctx:       logger,
+				Monitors:  monitor.NewRegistry(logger),
 			},
 			gateways: map[string]*gateway.Gateway{},
 		},


### PR DESCRIPTION
Previously, monitor clients were synchronously initialized during component startup. As a result, if a monitor server was down during during startup, the component would fail to start. This introduces a registry that encapsulates the initialization of monitor clients and exposes a simple API that allows components to retrieve the monitor clients that are ready at that point in time.

Fixes #396.