### PR TITLE
Add IDs and HardwareSerial to Uplink Messages on MQTT

### DIFF
--- a/core/handler/convert_lorawan.go
+++ b/core/handler/convert_lorawan.go
@@ -20,6 +20,8 @@ func (h *handler) ConvertFromLoRaWAN(ctx log.Interface, ttnUp *pb_broker.Dedupli
 		return err
 	}
 
+	appUp.HardwareSerial = dev.DevEUI.String()
+
 	// Check for LoRaWAN
 	if lorawan := ttnUp.ProtocolMetadata.GetLorawan(); lorawan == nil {
 		return errors.NewErrInvalidArgument("Activation", "does not contain LoRaWAN metadata")

--- a/core/types/uplink_message.go
+++ b/core/types/uplink_message.go
@@ -5,11 +5,12 @@ package types
 
 // UplinkMessage represents an application-layer uplink message
 type UplinkMessage struct {
-	AppID         string                 `json:"app_id,omitempty"`
-	DevID         string                 `json:"dev_id,omitempty"`
-	FPort         uint8                  `json:"port"`
-	FCnt          uint32                 `json:"counter"`
-	PayloadRaw    []byte                 `json:"payload_raw"`
-	PayloadFields map[string]interface{} `json:"payload_fields,omitempty"`
-	Metadata      Metadata               `json:"metadata,omitempty"`
+	AppID          string                 `json:"app_id,omitempty"`
+	DevID          string                 `json:"dev_id,omitempty"`
+	HardwareSerial string                 `json:"hardware_serial,omitempty"`
+	FPort          uint8                  `json:"port"`
+	FCnt           uint32                 `json:"counter"`
+	PayloadRaw     []byte                 `json:"payload_raw"`
+	PayloadFields  map[string]interface{} `json:"payload_fields,omitempty"`
+	Metadata       Metadata               `json:"metadata,omitempty"`
 }

--- a/mqtt/activations.go
+++ b/mqtt/activations.go
@@ -16,8 +16,6 @@ type ActivationHandler func(client Client, appID string, devID string, req types
 func (c *DefaultClient) PublishActivation(activation types.Activation) Token {
 	appID := activation.AppID
 	devID := activation.DevID
-	activation.AppID = ""
-	activation.DevID = ""
 	return c.PublishDeviceEvent(appID, devID, types.ActivationEvent, activation)
 }
 

--- a/mqtt/uplink.go
+++ b/mqtt/uplink.go
@@ -17,8 +17,6 @@ type UplinkHandler func(client Client, appID string, devID string, req types.Upl
 // PublishUplink publishes an uplink message to the MQTT broker
 func (c *DefaultClient) PublishUplink(dataUp types.UplinkMessage) Token {
 	topic := DeviceTopic{dataUp.AppID, dataUp.DevID, DeviceUplink, ""}
-	dataUp.AppID = ""
-	dataUp.DevID = ""
 	msg, err := json.Marshal(dataUp)
 	if err != nil {
 		return &simpleToken{fmt.Errorf("Unable to marshal the message payload")}


### PR DESCRIPTION
Intentionally *not* using `DevEUI` so that HardwareSerial can be MAC/EUI/UUID/...

Resolves #406