### PR TITLE
Restart monitor streams when token changes

### DIFF
--- a/api/monitor/client.go
+++ b/api/monitor/client.go
@@ -156,9 +156,10 @@ func (cl *Client) GatewayClient(id string) (gtwCl GatewayClient) {
 	if !ok {
 		cl.mutex.Lock()
 		gtwCl = &gatewayClient{
-			Ctx:    cl.Ctx.WithField("GatewayID", id),
-			client: cl,
-			id:     id,
+			Ctx:          cl.Ctx.WithField("GatewayID", id),
+			client:       cl,
+			id:           id,
+			tokenChanged: make(chan struct{}),
 		}
 		cl.gateways[id] = gtwCl
 		cl.mutex.Unlock()
@@ -173,7 +174,8 @@ type gatewayClient struct {
 
 	Ctx log.Interface
 
-	id, token string
+	id, token    string
+	tokenChanged chan struct{}
 
 	status struct {
 		init   sync.Once
@@ -199,18 +201,32 @@ type gatewayClient struct {
 
 // GatewayClient is used as the main client for Gateways to communicate with the monitor
 type GatewayClient interface {
-	SetToken(token string)
+	Close() (err error)
+
 	IsConfigured() bool
+
+	SetToken(token string)
+	TokenChanged() <-chan struct{}
+
 	SendStatus(status *gateway.Status) (err error)
 	SendUplink(msg *router.UplinkMessage) (err error)
 	SendDownlink(msg *router.DownlinkMessage) (err error)
-	Close() (err error)
 }
 
 func (cl *gatewayClient) SetToken(token string) {
 	cl.Lock()
 	defer cl.Unlock()
 	cl.token = token
+
+	close(cl.tokenChanged)
+	cl.tokenChanged = make(chan struct{})
+}
+
+func (cl *gatewayClient) TokenChanged() <-chan struct{} {
+	cl.RLock()
+	defer cl.RUnlock()
+
+	return cl.tokenChanged
 }
 
 func (cl *gatewayClient) IsConfigured() bool {

--- a/api/monitor/client_test.go
+++ b/api/monitor/client_test.go
@@ -77,6 +77,7 @@ func TestClient(t *testing.T) {
 		}
 
 		// After which statuses will get dropped
+		gtw.SendStatus(&gateway.Status{})
 		err = gtw.SendStatus(&gateway.Status{})
 		a.So(err, ShouldNotBeNil)
 
@@ -110,6 +111,7 @@ func TestClient(t *testing.T) {
 		}
 
 		// After which messages will get dropped
+		gtw.SendUplink(&router.UplinkMessage{})
 		err = gtw.SendUplink(&router.UplinkMessage{})
 		a.So(err, ShouldNotBeNil)
 
@@ -143,6 +145,7 @@ func TestClient(t *testing.T) {
 		}
 
 		// After which messages will get dropped
+		gtw.SendDownlink(&router.DownlinkMessage{})
 		err = gtw.SendDownlink(&router.DownlinkMessage{})
 		a.So(err, ShouldNotBeNil)
 
@@ -173,6 +176,7 @@ func TestClient(t *testing.T) {
 		}
 
 		// After which messages will get dropped
+		client.BrokerClient.SendUplink(&broker.DeduplicatedUplinkMessage{})
 		err = client.BrokerClient.SendUplink(&broker.DeduplicatedUplinkMessage{})
 		a.So(err, ShouldNotBeNil)
 
@@ -203,6 +207,7 @@ func TestClient(t *testing.T) {
 		}
 
 		// After which messages will get dropped
+		client.BrokerClient.SendDownlink(&broker.DownlinkMessage{})
 		err = client.BrokerClient.SendDownlink(&broker.DownlinkMessage{})
 		a.So(err, ShouldNotBeNil)
 

--- a/api/monitor/gateway_downlink.go
+++ b/api/monitor/gateway_downlink.go
@@ -67,7 +67,9 @@ func (cl *gatewayClient) monitorDownlink() {
 				break
 			case downlink, ok := <-cl.downlink.ch:
 				if ok {
-					if err := stream.Send(downlink); err == nil {
+					if err := stream.Send(downlink); err != nil {
+						cl.Ctx.WithError(errors.FromGRPCError(err)).Debug("Error sending downlink to monitor")
+					} else {
 						cl.Ctx.Debug("Sent downlink to monitor")
 					}
 				}

--- a/api/monitor/gateway_downlink.go
+++ b/api/monitor/gateway_downlink.go
@@ -73,9 +73,6 @@ func (cl *gatewayClient) monitorDownlink() {
 				}
 			}
 		}
-
-		retries++
-		time.Sleep(backoff.Backoff(retries))
 	}
 }
 

--- a/api/monitor/gateway_status.go
+++ b/api/monitor/gateway_status.go
@@ -73,9 +73,6 @@ func (cl *gatewayClient) monitorStatus() {
 				}
 			}
 		}
-
-		retries++
-		time.Sleep(backoff.Backoff(retries))
 	}
 }
 

--- a/api/monitor/gateway_status.go
+++ b/api/monitor/gateway_status.go
@@ -67,7 +67,9 @@ func (cl *gatewayClient) monitorStatus() {
 				break
 			case status, ok := <-cl.status.ch:
 				if ok {
-					if err := stream.Send(status); err == nil {
+					if err := stream.Send(status); err != nil {
+						cl.Ctx.WithError(errors.FromGRPCError(err)).Debug("Error sending status to monitor")
+					} else {
 						cl.Ctx.Debug("Sent status to monitor")
 					}
 				}

--- a/api/monitor/gateway_status.go
+++ b/api/monitor/gateway_status.go
@@ -20,7 +20,7 @@ func (cl *gatewayClient) initStatus() {
 
 func (cl *gatewayClient) monitorStatus() {
 	var retries int
-newStream:
+
 	for {
 		ctx, cancel := context.WithCancel(cl.Context())
 		cl.status.Lock()
@@ -39,39 +39,43 @@ newStream:
 		retries = 0
 		cl.Ctx.Debug("Opened new monitor status stream")
 
-		// The actual stream
-		go func() {
-			for {
-				select {
-				case <-ctx.Done():
-					return
-				case status, ok := <-cl.status.ch:
-					if ok {
-						stream.Send(status)
-						cl.Ctx.Debug("Sent status to monitor")
-					}
-				}
-			}
-		}()
+		var tokenChanged bool
 
-		msg := new(empty.Empty)
-		for {
-			if err := stream.RecvMsg(&msg); err != nil {
-				cl.Ctx.WithError(errors.FromGRPCError(err)).Warn("Received error on monitor status stream, closing...")
-				stream.CloseSend()
+		go func() {
+			if err := stream.RecvMsg(&empty.Empty{}); err != nil {
+				if !tokenChanged {
+					cl.Ctx.WithError(errors.FromGRPCError(err)).Warn("Received error on monitor status stream, closing...")
+					stream.CloseSend()
+				}
 				cl.Ctx.Debug("Closed monitor status stream")
 
 				cl.status.Lock()
 				cl.status.cancel()
 				cl.status.cancel = nil
 				cl.status.Unlock()
+			}
+		}()
 
-				retries++
-				time.Sleep(backoff.Backoff(retries))
-
-				continue newStream
+		for {
+			select {
+			case <-ctx.Done():
+				break
+			case <-cl.TokenChanged():
+				cl.Ctx.Debug("Restarting status stream with new token")
+				tokenChanged = true
+				stream.CloseSend()
+				break
+			case status, ok := <-cl.status.ch:
+				if ok {
+					if err := stream.Send(status); err == nil {
+						cl.Ctx.Debug("Sent status to monitor")
+					}
+				}
 			}
 		}
+
+		retries++
+		time.Sleep(backoff.Backoff(retries))
 	}
 }
 

--- a/api/monitor/gateway_uplink.go
+++ b/api/monitor/gateway_uplink.go
@@ -73,9 +73,6 @@ func (cl *gatewayClient) monitorUplink() {
 				}
 			}
 		}
-
-		retries++
-		time.Sleep(backoff.Backoff(retries))
 	}
 }
 

--- a/api/monitor/gateway_uplink.go
+++ b/api/monitor/gateway_uplink.go
@@ -67,7 +67,9 @@ func (cl *gatewayClient) monitorUplink() {
 				break
 			case uplink, ok := <-cl.uplink.ch:
 				if ok {
-					if err := stream.Send(uplink); err == nil {
+					if err := stream.Send(uplink); err != nil {
+						cl.Ctx.WithError(errors.FromGRPCError(err)).Debug("Error sending uplink to monitor")
+					} else {
 						cl.Ctx.Debug("Sent uplink to monitor")
 					}
 				}

--- a/api/router/client_streams.go
+++ b/api/router/client_streams.go
@@ -108,7 +108,7 @@ func NewMonitoredGatewayStatusStream(client RouterClientForGateway) GatewayStatu
 						break monitor // channel closed
 					}
 					ch <- msg
-				case <-s.client.TokenChange():
+				case <-s.client.TokenChanged():
 					s.ctx.Debug("Restarting GatewayStatus stream with new token")
 					break monitor
 				}
@@ -234,7 +234,7 @@ func NewMonitoredUplinkStream(client RouterClientForGateway) UplinkStream {
 						break monitor // channel closed
 					}
 					ch <- msg
-				case <-s.client.TokenChange():
+				case <-s.client.TokenChanged():
 					s.ctx.Debug("Restarting Uplink stream with new token")
 					break monitor
 				}
@@ -322,7 +322,7 @@ func NewMonitoredDownlinkStream(client RouterClientForGateway) DownlinkStream {
 			}
 
 			go func() {
-				<-s.client.TokenChange()
+				<-s.client.TokenChanged()
 				s.ctx.Debug("Restarting Downlink stream with new token")
 				s.cancel()
 			}()


### PR DESCRIPTION
@htdvisser  because of implementation, test results are unpredictable.
often they fail on https://github.com/TheThingsNetwork/ttn/blob/develop/api/monitor/client_test.go#L81 , for example. As for reason why(as far as I understand): we use the `RecvMsg` to determine if there is an error on stream, but that happens concurrently with the `stream.Send`, so there is no way determine which happens first. If the `Send` happens first, the buffer is not going to be full and there will be no error returned. I implemented a _"dirty"_ workaround by sending 2 messages.
I did not find a way to test if stream is indeed reopened on token change in current implementation of tests

closes #397 