### PR TITLE
Handle retries for confirmed uplinks

### DIFF
--- a/core/broker/uplink.go
+++ b/core/broker/uplink.go
@@ -167,13 +167,25 @@ func (b *broker) HandleUplink(uplink *pb.UplinkMessage) (err error) {
 		ctx = ctx.WithField("RealFCnt", macPayload.FHDR.FCnt)
 	}
 
-	if device.DisableFCntCheck {
-		// TODO: Add warning to message?
-	} else if device.FCntUp == 0 {
-
-	} else if macPayload.FHDR.FCnt <= device.FCntUp || macPayload.FHDR.FCnt-device.FCntUp > maxFCntGap {
-		// Replay attack or FCnt gap too big
-		return errors.NewErrNotFound("device with matching FCnt")
+	switch {
+	case macPayload.FHDR.FCnt > device.FCntUp && macPayload.FHDR.FCnt-device.FCntUp <= maxFCntGap:
+		// FCnt higher than latest and within max FCnt gap (normal case)
+	case device.DisableFCntCheck:
+		// FCnt Check disabled. Rely on MIC check only
+	case device.FCntUp == 0:
+		// FCntUp is reset. We don't know where the device will start sending.
+	case macPayload.FHDR.FCnt == device.FCntUp:
+		if phyPayload.MHDR.MType == lorawan.ConfirmedDataUp {
+			// Retry of confirmed uplink
+			break
+		}
+		fallthrough
+	case macPayload.FHDR.FCnt <= device.FCntUp:
+		return errors.NewErrInvalidArgument("FCnt", "not high enough")
+	case macPayload.FHDR.FCnt-device.FCntUp > maxFCntGap:
+		return errors.NewErrInvalidArgument("FCnt", "too high")
+	default:
+		return errors.NewErrInternal("FCnt check failed")
 	}
 
 	// Add FCnt to Metadata (because it's not marshaled in lorawan payload)

--- a/core/broker/uplink_test.go
+++ b/core/broker/uplink_test.go
@@ -112,7 +112,7 @@ func TestHandleUplink(t *testing.T) {
 		GatewayMetadata:  &gateway.RxMetadata{Snr: 1.2, GatewayId: gtwID},
 		ProtocolMetadata: &protocol.RxMetadata{Protocol: &protocol.RxMetadata_Lorawan{Lorawan: &pb_lorawan.Metadata{}}},
 	})
-	a.So(err, ShouldHaveSameTypeAs, &errors.ErrNotFound{})
+	a.So(err, ShouldHaveSameTypeAs, &errors.ErrInvalidArgument{})
 
 	// Disable FCnt Check
 	b.uplinkDeduplicator = NewDeduplicator(10 * time.Millisecond)

--- a/core/handler/device/device.go
+++ b/core/handler/device/device.go
@@ -44,6 +44,7 @@ type Device struct {
 	DevAddr types.DevAddr `redis:"dev_addr"`
 	NwkSKey types.NwkSKey `redis:"nwk_s_key"`
 	AppSKey types.AppSKey `redis:"app_s_key"`
+	FCntUp  uint32        `redis:"f_cnt_up"` // Only used to detect retries
 
 	CurrentDownlink *types.DownlinkMessage `redis:"current_downlink"`
 	NextDownlink    *types.DownlinkMessage `redis:"next_downlink"`

--- a/core/types/uplink_message.go
+++ b/core/types/uplink_message.go
@@ -10,6 +10,7 @@ type UplinkMessage struct {
 	HardwareSerial string                 `json:"hardware_serial,omitempty"`
 	FPort          uint8                  `json:"port"`
 	FCnt           uint32                 `json:"counter"`
+	IsRetry        bool                   `json:"is_retry,omitempty"`
 	PayloadRaw     []byte                 `json:"payload_raw"`
 	PayloadFields  map[string]interface{} `json:"payload_fields,omitempty"`
 	Metadata       Metadata               `json:"metadata,omitempty"`

--- a/mqtt/README.md
+++ b/mqtt/README.md
@@ -19,6 +19,7 @@
   "hardware_serial": "0102030405060708", // In case of LoRaWAN: the DevEUI
   "port": 1,                          // LoRaWAN FPort
   "counter": 2,                       // LoRaWAN frame counter
+  "is_retry": false,                  // Is set to true if this message is a retry (you could also detect this from the counter)
   "payload_raw": "AQIDBA==",          // Base64 encoded payload: [0x01, 0x02, 0x03, 0x04]
   "payload_fields": {},               // Object containing the results from the payload functions - left out when empty
   "metadata": {
@@ -44,7 +45,7 @@
 }
 ```
 
-Note: Some values may be omitted if they are `null`, `""` or `0`.
+Note: Some values may be omitted if they are `null`, `false`, `""` or `0`.
 
 **Usage (Mosquitto):** `mosquitto_sub -h <Region>.thethings.network:1883 -d -t 'my-app-id/devices/my-dev-id/up'`
 


### PR DESCRIPTION
Resolves #272 

Remaining question: What should the Handler do with retries?

- Just publish on MQTT (assuming the application checks the `counter` value)
- Publish on MQTT, but indicate that it's a retry (assuming the application will check for this flag)
- Don't publish on MQTT at all

Requires change in #442: now that we know a downlink (ACK) was not received by the node, we should also re-send the downlink message.