### PR TITLE
Implement data migration mechanism for RedisMapStore

### DIFF
--- a/core/storage/redis_map_migrate.go
+++ b/core/storage/redis_map_migrate.go
@@ -1,0 +1,119 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package storage
+
+import (
+	"strings"
+
+	"github.com/TheThingsNetwork/ttn/utils/errors"
+	redis "gopkg.in/redis.v5"
+)
+
+// VersionKey indicates the data (schema) version
+const VersionKey = "_version"
+
+type hasDBVersion interface {
+	DBVersion() string
+}
+
+// MigrateFunction migrates data from its old version to the latest
+type MigrateFunction func(client *redis.Client, key string, input map[string]string) (version string, output map[string]string, err error)
+
+// AddMigration adds a data migration for a version
+func (s *RedisMapStore) AddMigration(version string, migrate MigrateFunction) {
+	s.migrations[version] = migrate
+}
+
+// Migrate all documents matching the selector
+func (s *RedisMapStore) Migrate(selector string) error {
+	if selector == "" {
+		selector = "*"
+	}
+	if !strings.HasPrefix(selector, s.prefix) {
+		selector = s.prefix + selector
+	}
+
+	var cursor uint64
+	for {
+		keys, next, err := s.client.Scan(cursor, selector, 0).Result()
+		if err != nil {
+			return err
+		}
+
+		for _, key := range keys {
+			// Get migrates the item
+			_, err := s.Get(key)
+
+			// NotFound if item was deleted since Scan started
+			if errors.GetErrType(err) == errors.NotFound {
+				continue
+			}
+
+			// TxFailedError is returned if the item was changed by a concurrent process.
+			// If it was a parallel migration, we don't have to do anything
+			// Otherwise, this item will be migrated with the next Get
+			if err == redis.TxFailedErr {
+				continue
+			}
+
+			// Any other error should be returned
+			if err != nil {
+				return err
+			}
+		}
+
+		cursor = next
+		if cursor == 0 {
+			break
+		}
+	}
+
+	return nil
+}
+
+func (s *RedisMapStore) migrate(key string, obj map[string]string) (map[string]string, error) {
+	var err error
+	version, _ := obj[VersionKey]
+	migration, ok := s.migrations[version]
+
+	if !ok {
+		return obj, nil
+	}
+
+	var oldFields []string
+	for k := range obj {
+		oldFields = append(oldFields, k)
+	}
+
+	err = s.client.Watch(func(tx *redis.Tx) error { // Make sure objects are not changed while we're migrating them
+		// As long as there are migrations to do
+		for ok {
+			version, obj, err = migration(s.client, key, obj)
+			if err != nil {
+				return err
+			}
+			obj[VersionKey] = version
+			migration, ok = s.migrations[version]
+		}
+
+		// Collect deleted fields
+		var deletedFields []string
+		for _, k := range oldFields {
+			if _, ok := obj[k]; !ok {
+				deletedFields = append(deletedFields, k)
+			}
+		}
+
+		// Commit the new version
+		_, err := tx.Pipelined(func(pipe *redis.Pipeline) error {
+			pipe.HMSet(key, obj)
+			pipe.HDel(key, deletedFields...)
+			return nil
+		})
+
+		return err
+	}, key)
+
+	return obj, err
+}

--- a/core/storage/redis_map_migrate_test.go
+++ b/core/storage/redis_map_migrate_test.go
@@ -1,0 +1,83 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package storage
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/assertions"
+	redis "gopkg.in/redis.v5"
+)
+
+type oldStruct struct {
+	FirstName string `redis:"first_name"`
+	LastName  string `redis:"last_name"`
+}
+
+func (s *oldStruct) DBVersion() string {
+	return ""
+}
+
+type newStruct struct {
+	Name string `redis:"name"`
+}
+
+func (s *newStruct) DBVersion() string {
+	return "1"
+}
+
+func TestRedisMapMigrate(t *testing.T) {
+	a := New(t)
+	c := getRedisClient()
+	s := NewRedisMapStore(c, "test-redis-map-migrate")
+	a.So(s, ShouldNotBeNil)
+
+	defer func() {
+		s.Delete("test")
+	}()
+
+	s.SetBase(&oldStruct{}, "")
+	s.Create("test", &oldStruct{
+		FirstName: "First",
+		LastName:  "Last",
+	})
+
+	{
+		oldI, _ := s.Get("test")
+		old := oldI.(*oldStruct)
+		a.So(old.FirstName, ShouldEqual, "First")
+		a.So(old.LastName, ShouldEqual, "Last")
+	}
+
+	{
+		err := s.Migrate("")
+		a.So(err, ShouldBeNil)
+	}
+
+	{
+		s.SetBase(&newStruct{}, "")
+		newI, _ := s.Get("test")
+		new := newI.(*newStruct)
+		a.So(new.Name, ShouldBeEmpty)
+	}
+
+	{
+		s.SetBase(&newStruct{}, "")
+		s.AddMigration("", func(_ *redis.Client, key string, obj map[string]string) (string, map[string]string, error) {
+			firstName, _ := obj["first_name"]
+			delete(obj, "first_name")
+
+			lastName, _ := obj["last_name"]
+			delete(obj, "last_name")
+
+			obj["name"] = firstName + " " + lastName
+
+			return "1", obj, nil
+		})
+		newI, _ := s.Get("test")
+		new := newI.(*newStruct)
+		a.So(new.Name, ShouldEqual, "First Last")
+	}
+
+}


### PR DESCRIPTION
Idea:

- When data needs to be migrated, the "version" is changed.
- Migration functions are registered in the `RedisMapStore`. These functions upgrade the data from one version to another version.
- Migration is done at the moment the item is accessed (if needed). This allows newer versions of the application to keep working with older data, so no downtime during migration.
- The `Migrate(selector string)` function lists all matching objects and migrates these in the background (if needed)

This method is _up only_. Reverting to an older version of the data is not possible.