### PR TITLE
Do not throw error when no Decoder is set

### DIFF
--- a/core/handler/convert_fields.go
+++ b/core/handler/convert_fields.go
@@ -78,7 +78,7 @@ var timeOut = 100 * time.Millisecond
 // Decode decodes the payload using the Decoder function into a map
 func (f *UplinkFunctions) Decode(payload []byte, port uint8) (map[string]interface{}, error) {
 	if f.Decoder == "" {
-		return nil, errors.NewErrInternal("Decoder function not set")
+		return nil, nil
 	}
 
 	env := map[string]interface{}{

--- a/core/handler/convert_fields_test.go
+++ b/core/handler/convert_fields_test.go
@@ -189,7 +189,7 @@ func TestProcessInvalidUplinkFunction(t *testing.T) {
 		Decoder: ``,
 	}
 	_, _, err := functions.Process([]byte{40, 110}, 1)
-	a.So(err, ShouldNotBeNil)
+	a.So(err, ShouldBeNil)
 
 	// Invalid Function
 	functions = &UplinkFunctions{


### PR DESCRIPTION
Fix `No Decoder set` error.