### PR TITLE
Added a Dial function to use TLS without fallback to unsecure

### DIFF
--- a/api/dial.go
+++ b/api/dial.go
@@ -87,6 +87,12 @@ func Dial(address string) (*grpc.ClientConn, error) {
 	return dial(address, tlsConfig, true)
 }
 
+// DialSafely dials an address with TLS only and fails if the server is not using TLS with a known CA
+func DialSafely(address string) (*grpc.ClientConn, error) {
+	tlsConfig := &tls.Config{RootCAs: RootCAs}
+	return dial(address, tlsConfig, false)
+}
+
 // DialWithCert dials the address using the given TLS cert
 func DialWithCert(address string, cert string) (*grpc.ClientConn, error) {
 	rootCAs := x509.NewCertPool()


### PR DESCRIPTION
It might be useful in some cases to tolerate only secure connections with registered CAs (If the client wants to use only TLS without fallback if the server does not use it).