### PR TITLE
Fix/safe crypto

### DIFF
--- a/core/handler/activation.go
+++ b/core/handler/activation.go
@@ -188,7 +188,7 @@ func (h *handler) HandleActivation(activation *pb_broker.DeduplicatedDeviceActiv
 		// NOTE: As DevNonces are only 2 bytes, we will start rejecting those before we run out of AppNonces.
 		// It might just take some time to get one we didn't use yet...
 		alreadyUsed = false
-		copy(appNonce[:], random.Bytes(3))
+		random.FillBytes(appNonce[:])
 		for _, usedNonce := range dev.UsedAppNonces {
 			if usedNonce == appNonce {
 				alreadyUsed = true

--- a/core/networkserver/activation.go
+++ b/core/networkserver/activation.go
@@ -21,7 +21,7 @@ import (
 func (n *networkServer) getDevAddr(constraints ...string) (types.DevAddr, error) {
 	// Generate random DevAddr bytes
 	var devAddr types.DevAddr
-	copy(devAddr[:], random.Bytes(4))
+	random.FillBytes(devAddr[:])
 
 	// Get a random prefix that matches the constraints
 	prefixes := n.GetPrefixesFor(constraints...)

--- a/ttnctl/cmd/devices_personalize.go
+++ b/ttnctl/cmd/devices_personalize.go
@@ -47,7 +47,7 @@ var devicesPersonalizeCmd = &cobra.Command{
 			}
 		} else {
 			ctx.Info("Generating random NwkSKey...")
-			copy(nwkSKey[:], random.Bytes(16))
+			random.FillBytes(nwkSKey[:])
 		}
 
 		var appSKey types.AppSKey
@@ -58,7 +58,7 @@ var devicesPersonalizeCmd = &cobra.Command{
 			}
 		} else {
 			ctx.Info("Generating random AppSKey...")
-			copy(appSKey[:], random.Bytes(16))
+			random.FillBytes(appSKey[:])
 		}
 
 		conn, manager := util.GetHandlerManager(ctx, appID)

--- a/ttnctl/cmd/devices_register.go
+++ b/ttnctl/cmd/devices_register.go
@@ -47,7 +47,7 @@ var devicesRegisterCmd = &cobra.Command{
 			}
 		} else {
 			ctx.Info("Generating random DevEUI...")
-			copy(devEUI[1:], random.Bytes(7))
+			random.FillBytes(devEUI[1:])
 		}
 
 		var appKey types.AppKey
@@ -58,7 +58,7 @@ var devicesRegisterCmd = &cobra.Command{
 			}
 		} else {
 			ctx.Info("Generating random AppKey...")
-			copy(appKey[:], random.Bytes(16))
+			random.FillBytes(appKey[:])
 		}
 
 		device := &handler.Device{

--- a/utils/random/random.go
+++ b/utils/random/random.go
@@ -5,6 +5,7 @@ package random
 
 import (
 	crypto "crypto/rand"
+	"encoding/base64"
 	"encoding/binary"
 	"fmt"
 	"math"
@@ -63,6 +64,14 @@ func (r *TTNRandom) String(n int) string {
 	}
 
 	return string(b)
+}
+
+// StrongString creates a cryptographically strong random string
+// of length n, it uses the characters of base64.URLEncoding
+func StrongString(n int) string {
+	l := base64.RawURLEncoding.DecodedLen(n)
+	b := Bytes(l + 2)
+	return base64.RawURLEncoding.EncodeToString(b)
 }
 
 // Token generate a random 2-bytes token

--- a/utils/random/random.go
+++ b/utils/random/random.go
@@ -190,9 +190,15 @@ func Lsnr() float32 {
 // Bytes generates a random byte slice of length n
 func Bytes(n int) []byte {
 	p := make([]byte, n)
+	FillBytes(p)
+	return p
+}
+
+// FillBytes fills the byte slice with random bytes. It does not use an
+// intermediate buffer
+func FillBytes(p []byte) {
 	_, err := crypto.Read(p)
 	if err != nil {
 		panic(fmt.Errorf("random.Bytes: %s", err))
 	}
-	return p
 }

--- a/utils/random/random.go
+++ b/utils/random/random.go
@@ -4,6 +4,7 @@
 package random
 
 import (
+	crypto "crypto/rand"
 	"encoding/binary"
 	"fmt"
 	"math"
@@ -146,15 +147,6 @@ func (r *TTNRandom) Lsnr() float32 {
 	return float32(math.Floor((-0.1*math.Exp(x)+5.5)*10) / 10)
 }
 
-// Bytes generates a random byte slice of length n
-func (r *TTNRandom) Bytes(n int) []byte {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	p := make([]byte, n)
-	r.rand.Read(p)
-	return p
-}
-
 // Intn returns random int with max n
 func Intn(n int) int {
 	return global.Intn(n)
@@ -197,5 +189,10 @@ func Lsnr() float32 {
 
 // Bytes generates a random byte slice of length n
 func Bytes(n int) []byte {
-	return global.Bytes(n)
+	p := make([]byte, n)
+	_, err := crypto.Read(p)
+	if err != nil {
+		panic(fmt.Errorf("random.Bytes: %s", err))
+	}
+	return p
 }


### PR DESCRIPTION
- Uses the `crypto/rand` package in lieu of `math/rand` for safer tokens and keys.
- Adds a `FillBytes` helper that fills a byte slice completely without using a buffer and use this in all the places `random.Bytes` was used. This should improve performance.
- Add `random.StrongString` which generates a cryptographically strong random string in the `base64.RawURLEncoding`. It is a lot slower than `random.String`:
```
BenchmarkString-4         	 3000000	       365 ns/op
BenchmarkStrongString-4   	 1000000	      2206 ns/op
```
However, it does not need to acquire the lock in the global `TTNRandom`, which, in the end, might improve performance. I propose we remove `String` in favor of `StrongString` altogether.