### PR TITLE
Validate token subject as well as issuer

### DIFF
--- a/api/context.go
+++ b/api/context.go
@@ -33,7 +33,7 @@ func TokenFromMetadata(md metadata.MD) (string, error) {
 }
 
 // TokenFromContext gets the token from the context or returns ErrNoToken
-func TokenFromContext(ctx context.Context) (token string, err error) {
+func TokenFromContext(ctx context.Context) (string, error) {
 	md := MetadataFromContext(ctx)
 	return TokenFromMetadata(md)
 }
@@ -53,7 +53,7 @@ func KeyFromMetadata(md metadata.MD) (string, error) {
 }
 
 // KeyFromContext gets the key from the context or returns ErrNoKey
-func KeyFromContext(ctx context.Context) (key string, err error) {
+func KeyFromContext(ctx context.Context) (string, error) {
 	md := MetadataFromContext(ctx)
 	return KeyFromMetadata(md)
 }
@@ -73,7 +73,7 @@ func IDFromMetadata(md metadata.MD) (string, error) {
 }
 
 // IDFromContext gets the key from the context or returns ErrNoID
-func IDFromContext(ctx context.Context) (token string, err error) {
+func IDFromContext(ctx context.Context) (string, error) {
 	md := MetadataFromContext(ctx)
 	return IDFromMetadata(md)
 }
@@ -144,7 +144,7 @@ func LimitAndOffsetFromContext(ctx context.Context) (limit, offset uint64, err e
 }
 
 // ContextWithLimitAndOffset returns a context with the limit and offset
-func ContextWithLimitAndOffset(ctx context.Context, limit uint64, offset uint64) context.Context {
+func ContextWithLimitAndOffset(ctx context.Context, limit, offset uint64) context.Context {
 	var pairs []string
 	if limit != 0 {
 		pairs = append(pairs, "limit", strconv.FormatUint(limit, 10))

--- a/api/discovery/client.go
+++ b/api/discovery/client.go
@@ -13,7 +13,6 @@ import (
 	"github.com/bluele/gcache"
 	"golang.org/x/net/context" // See https://github.com/grpc/grpc-go/issues/711
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/metadata"
 )
 
 // CacheSize indicates the number of components that are cached
@@ -86,13 +85,10 @@ func (c *DefaultClient) getContext(token string) context.Context {
 	if token == "" {
 		token = c.tokenFunc()
 	}
-	md := metadata.Pairs(
-		"service-name", c.self.ServiceName,
-		"id", c.self.Id,
-		"token", token,
-		"net-address", c.self.NetAddress,
-	)
-	ctx := metadata.NewContext(context.Background(), md)
+	ctx := context.Background()
+	ctx = api.ContextWithID(ctx, c.self.Id)
+	ctx = api.ContextWithServiceInfo(ctx, c.self.ServiceName, c.self.ServiceVersion, c.self.NetAddress)
+	ctx = api.ContextWithToken(ctx, token)
 	return ctx
 }
 

--- a/api/monitor/client.go
+++ b/api/monitor/client.go
@@ -14,7 +14,6 @@ import (
 	"github.com/TheThingsNetwork/ttn/utils/errors"
 	"golang.org/x/net/context" // See https://github.com/grpc/grpc-go/issues/711"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/metadata"
 )
 
 // BufferSize gives the size for the monitor buffers
@@ -231,10 +230,10 @@ func (cl *gatewayClient) Close() (err error) {
 func (cl *gatewayClient) Context() (monitorContext context.Context) {
 	cl.RLock()
 	defer cl.RUnlock()
-	return metadata.NewContext(context.Background(), metadata.Pairs(
-		"id", cl.id,
-		"token", cl.token,
-	))
+	ctx := context.Background()
+	ctx = api.ContextWithID(ctx, cl.id)
+	ctx = api.ContextWithToken(ctx, cl.token)
+	return ctx
 }
 
 type brokerClient struct {

--- a/api/router/gateway_client.go
+++ b/api/router/gateway_client.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 
 	"github.com/TheThingsNetwork/go-utils/log"
+	"github.com/TheThingsNetwork/ttn/api"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc/metadata"
 )
 
 // RouterClientForGateway is a RouterClient for a specific gateway
@@ -67,11 +67,9 @@ func (c *routerClientForGateway) SetLogger(logger log.Interface) {
 func (c *routerClientForGateway) getContext() context.Context {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	md := metadata.Pairs(
-		"id", c.gatewayID,
-		"token", c.token,
-	)
-	return metadata.NewContext(c.bgCtx, md)
+	ctx := api.ContextWithID(c.bgCtx, c.gatewayID)
+	ctx = api.ContextWithToken(ctx, c.token)
+	return ctx
 }
 
 func (c *routerClientForGateway) SetToken(token string) {

--- a/core/component/auth.go
+++ b/core/component/auth.go
@@ -24,7 +24,6 @@ import (
 	"github.com/TheThingsNetwork/ttn/utils/security"
 	jwt "github.com/dgrijalva/jwt-go"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc/metadata"
 )
 
 // InitAuth initializes Auth functionality
@@ -173,24 +172,15 @@ func (c *Component) BuildJWT() (string, error) {
 
 // GetContext returns a context for outgoing RPC request. If token is "", this function will generate a short lived token from the component
 func (c *Component) GetContext(token string) context.Context {
-	var serviceName, serviceVersion, id, netAddress string
+	ctx := context.Background()
 	if c.Identity != nil {
-		serviceName = c.Identity.ServiceName
-		id = c.Identity.Id
+		ctx = api.ContextWithID(ctx, c.Identity.Id)
+		ctx = api.ContextWithServiceInfo(ctx, c.Identity.ServiceName, c.Identity.ServiceVersion, c.Identity.NetAddress)
 		if token == "" {
-			token, _ = c.BuildJWT()
+			token, _ := c.BuildJWT()
+			ctx = api.ContextWithToken(ctx, token)
 		}
-		serviceVersion = c.Identity.ServiceVersion
-		netAddress = c.Identity.NetAddress
 	}
-	md := metadata.Pairs(
-		"service-name", serviceName,
-		"service-version", serviceVersion,
-		"id", id,
-		"token", token,
-		"net-address", netAddress,
-	)
-	ctx := metadata.NewContext(context.Background(), md)
 	return ctx
 }
 
@@ -235,43 +225,28 @@ func (c *Component) ValidateNetworkContext(ctx context.Context) (component *pb_d
 		}
 	}()
 
-	md, ok := metadata.FromContext(ctx)
-	if !ok {
-		err = errors.NewErrInternal("Could not get metadata from context")
-		return
-	}
-	var id, serviceName, token string
-	if ids, ok := md["id"]; ok && len(ids) == 1 {
-		id = ids[0]
-	}
-	if id == "" {
-		err = errors.NewErrInvalidArgument("Metadata", "id missing")
-		return
-	}
-	if serviceNames, ok := md["service-name"]; ok && len(serviceNames) == 1 {
-		serviceName = serviceNames[0]
-	}
-	if serviceName == "" {
-		err = errors.NewErrInvalidArgument("Metadata", "service-name missing")
-		return
-	}
-	if tokens, ok := md["token"]; ok && len(tokens) == 1 {
-		token = tokens[0]
+	id, err := api.IDFromContext(ctx)
+	if err != nil {
+		return nil, err
 	}
 
-	var announcement *pb_discovery.Announcement
-	announcement, err = c.Discover(serviceName, id)
+	serviceName, _, _, _ := api.ServiceInfoFromContext(ctx)
+	if serviceName == "" {
+		return nil, errors.NewErrInvalidArgument("Metadata", "service-name missing")
+	}
+
+	announcement, err := c.Discover(serviceName, id)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	if announcement.PublicKey == "" {
 		return announcement, nil
 	}
 
-	if token == "" {
-		err = errors.NewErrInvalidArgument("Metadata", "token missing")
-		return
+	token, err := api.TokenFromContext(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	var claims *jwt.StandardClaims

--- a/core/component/auth.go
+++ b/core/component/auth.go
@@ -280,7 +280,11 @@ func (c *Component) ValidateNetworkContext(ctx context.Context) (component *pb_d
 		return
 	}
 	if claims.Issuer != id {
-		err = errors.NewErrInvalidArgument("Metadata", "token was issued by different component id")
+		err = errors.NewErrPermissionDenied(fmt.Sprintf("Token was issued by %s, not by %s", claims.Issuer, id))
+		return
+	}
+	if claims.Subject != "" && claims.Subject != claims.Issuer && claims.Subject != c.Identity.Id {
+		err = errors.NewErrPermissionDenied(fmt.Sprintf("Token was issued to connect with %s, not with %s", claims.Subject, c.Identity.Id))
 		return
 	}
 


### PR DESCRIPTION
In the future we want to use the "sub" field in network tokens to make it impossible for a malicious server to pretend being the client. When authenticating to a server, the client (issuer) generates a JWT with the server's id as subject of the token. This token will only be valid for connecting with this specific server and can't be used to connect to another server.

for example:

Currently, when router `a` connects to broker `b` it generates a token (`iss:a,sub:a`). This means a malicious broker can now use this token to connect to a broker `c`, pretending to be `a`. In the future, router `a` will connect to broker `b` with a token (iss:`a`,sub:`b`). Broker `c` will reject this token, because it was meant for broker `b`, not `c`.