### PR TITLE
Add govendor to deps

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,7 @@
 tap 'homebrew/bundle'
 
 brew 'go'
+brew 'govendor'
 brew 'rabbitmq', restart_service: true
 brew 'protobuf'
 brew 'redis', restart_service: true


### PR DESCRIPTION
`govendor` is needed to properly install, e.g.:
```
➜  ttn git:(develop) make dev-deps
govendor sync -v
bash: govendor: command not found
make: *** [deps] Error 127
```