### PR TITLE
Remove `-v` flag from govendor sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ build-deps:
 	@command -v govendor > /dev/null || go get "github.com/kardianos/govendor"
 
 deps: build-deps
-	govendor sync -v
+	govendor sync
 
 dev-deps: deps
 	@command -v protoc-gen-gogofast > /dev/null || go get github.com/gogo/protobuf/protoc-gen-gogofast


### PR DESCRIPTION
`govendor sync` does not have a flag `-v`:

```
govendor sync
	Ensures the contents of the vendor folder matches the vendor file.
	Options:
		-n           dry run, print out action only
		-insecure    allow downloading over insecure connection
```

and thus fails with:
```
➜  ttn git:(develop) make dev-deps
govendor sync -v
Error: flag provided but not defined: -v
```