### PR TITLE
Add helpers to determine error type

### DIFF
--- a/utils/errors/errors.go
+++ b/utils/errors/errors.go
@@ -44,18 +44,27 @@ func GetErrType(err error) ErrType {
 	return Unknown
 }
 
+// IsPermissionDenied returns whether error type is PermissionDenied
 func IsPermissionDenied(err error) bool {
 	return GetErrType(err) == PermissionDenied
 }
+
+// IsNotFound returns whether error type is NotFound
 func IsNotFound(err error) bool {
 	return GetErrType(err) == NotFound
 }
+
+// IsInvalidArgument returns whether error type is InvalidArgument
 func IsInvalidArgument(err error) bool {
 	return GetErrType(err) == InvalidArgument
 }
+
+// IsInternal returns whether error type is Internal
 func IsInternal(err error) bool {
 	return GetErrType(err) == Internal
 }
+
+// IsAlreadyExists returns whether error type is AlreadyExists
 func IsAlreadyExists(err error) bool {
 	return GetErrType(err) == AlreadyExists
 }

--- a/utils/errors/errors.go
+++ b/utils/errors/errors.go
@@ -44,6 +44,22 @@ func GetErrType(err error) ErrType {
 	return Unknown
 }
 
+func IsPermissionDenied(err error) bool {
+	return GetErrType(err) == PermissionDenied
+}
+func IsNotFound(err error) bool {
+	return GetErrType(err) == NotFound
+}
+func IsInvalidArgument(err error) bool {
+	return GetErrType(err) == InvalidArgument
+}
+func IsInternal(err error) bool {
+	return GetErrType(err) == Internal
+}
+func IsAlreadyExists(err error) bool {
+	return GetErrType(err) == AlreadyExists
+}
+
 // BuildGRPCError returns the error with a GRPC code
 func BuildGRPCError(err error) error {
 	if err == nil {


### PR DESCRIPTION
on my machine tests fail with
```shell
api/monitor/monitor_test.go:15:2: cannot find package "github.com/htdvisser/grpc-testing/test" in any of:
	/home/rvolosatovs/src/github.com/TheThingsNetwork/ttn/vendor/github.com/htdvisser/grpc-testing/test (vendor tree)
	/usr/lib/go/src/github.com/htdvisser/grpc-testing/test (from $GOROOT)
	/home/rvolosatovs/src/github.com/htdvisser/grpc-testing/test (from $GOPATH)
```
~@htdvisser please fix and rebase~