### PR TITLE
Close connection before retrying

### DIFF
--- a/api/dial.go
+++ b/api/dial.go
@@ -25,7 +25,9 @@ func Dial(target string) (*grpc.ClientConn, error) {
 	if _, ok := err.(tls.RecordHeaderError); ok && AllowInsecureFallback {
 		log.Get().Warn("Could not connect to gRPC server with TLS, will reconnect without TLS")
 		log.Get().Warnf("This is a security risk, you should enable TLS on %s", target)
+		pool.Global.Close(target)
 		conn, err = pool.Global.DialInsecure(target)
+
 	}
 	return conn, err
 }


### PR DESCRIPTION
Closes the connection in the pool before retrying it with different dial options.