### PR TITLE
Random broker message generators, proper ID formatting

### DIFF
--- a/api/broker/random.go
+++ b/api/broker/random.go
@@ -1,5 +1,6 @@
 // Copyright © 2017 The Things Network
 // Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
 package broker
 
 import (

--- a/api/broker/random.go
+++ b/api/broker/random.go
@@ -1,0 +1,137 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+package broker
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/TheThingsNetwork/ttn/api/gateway"
+	"github.com/TheThingsNetwork/ttn/api/protocol"
+	"github.com/TheThingsNetwork/ttn/api/protocol/lorawan"
+	"github.com/TheThingsNetwork/ttn/utils/random"
+)
+
+func randomDeduplicatedUplinkMessage() *DeduplicatedUplinkMessage {
+	appEui := random.AppEUI()
+	devEui := random.DevEUI()
+	md := make([]*gateway.RxMetadata, random.Intn(10))
+	for i := range md {
+		md[i] = gateway.RandomRxMetadata()
+	}
+	return &DeduplicatedUplinkMessage{
+		AppEui:          &appEui,
+		DevEui:          &devEui,
+		AppId:           random.AppID(),
+		DevId:           random.DevID(),
+		GatewayMetadata: md,
+	}
+}
+
+// RandomLorawanDeduplicatedJoinRequest returns randomly generated lorawan join request.
+// Used for testing.
+func RandomLorawanDeduplicatedJoinRequest(modulation ...lorawan.Modulation) *DeduplicatedUplinkMessage {
+	msg := randomDeduplicatedUplinkMessage()
+	msg.ProtocolMetadata = protocol.RandomLorawanRxMetadata(modulation...)
+	msg.Payload = lorawan.RandomPayload(lorawan.MType_JOIN_REQUEST)
+	return msg
+}
+
+// RandomLorawanConfirmedDeduplicatedUplink returns randomly generated confirmed lorawan uplink message.
+// Used for testing.
+func RandomLorawanConfirmedDeduplicatedUplink(modulation ...lorawan.Modulation) *DeduplicatedUplinkMessage {
+	msg := randomDeduplicatedUplinkMessage()
+	msg.ProtocolMetadata = protocol.RandomLorawanRxMetadata(modulation...)
+	msg.Payload = lorawan.RandomPayload(lorawan.MType_CONFIRMED_UP)
+	return msg
+}
+
+// RandomLorawanUnconfirmedDeduplicatedUplink returns randomly generated unconfirmed lorawan uplink message.
+// Used for testing.
+func RandomLorawanUnconfirmedDeduplicatedUplink(modulation ...lorawan.Modulation) *DeduplicatedUplinkMessage {
+	msg := randomDeduplicatedUplinkMessage()
+	msg.ProtocolMetadata = protocol.RandomLorawanRxMetadata(modulation...)
+	msg.Payload = lorawan.RandomPayload(lorawan.MType_UNCONFIRMED_UP)
+	return msg
+}
+
+// RandomLorawanDeduplicatedUplinkMessage returns randomly generated lorawan uplink message(join request, confirmed or unconfirmed uplink).
+// Used for testing.
+func RandomLorawanDeduplicatedUplinkMessage(modulation ...lorawan.Modulation) *DeduplicatedUplinkMessage {
+	switch rand.Intn(3) {
+	case 0:
+		return RandomLorawanDeduplicatedJoinRequest(modulation...)
+	case 1:
+		return RandomLorawanConfirmedDeduplicatedUplink(modulation...)
+	default:
+		return RandomLorawanUnconfirmedDeduplicatedUplink(modulation...)
+	}
+}
+
+func randomDownlinkMessage() *DownlinkMessage {
+	appEui := random.AppEUI()
+	devEui := random.DevEUI()
+	return &DownlinkMessage{
+		AppEui: &appEui,
+		DevEui: &devEui,
+		AppId:  random.AppID(),
+		DevId:  random.DevID(),
+		DownlinkOption: &DownlinkOption{
+			GatewayConfig:  gateway.RandomTxConfiguration(),
+			ProtocolConfig: protocol.RandomTxConfiguration(),
+			Score:          uint32(random.Intn(100)),
+			Deadline:       int64(time.Now().Nanosecond() + random.Intn(10000)),
+			GatewayId:      random.ID(),
+			Identifier:     random.ID(),
+		},
+	}
+}
+
+// RandomLorawanJoinAccept returns randomly generated lorawan join request.
+// Used for testing.
+func RandomLorawanJoinAccept() *DownlinkMessage {
+	msg := randomDownlinkMessage()
+	msg.Payload = lorawan.RandomPayload(lorawan.MType_JOIN_ACCEPT)
+	return msg
+}
+
+// RandomLorawanConfirmedDownlink returns randomly generated confirmed lorawan uplink message.
+// Used for testing.
+func RandomLorawanConfirmedDownlink() *DownlinkMessage {
+	msg := randomDownlinkMessage()
+	msg.Payload = lorawan.RandomPayload(lorawan.MType_CONFIRMED_DOWN)
+	return msg
+}
+
+// RandomLorawanUnconfirmedDownlink returns randomly generated unconfirmed lorawan uplink message.
+// Used for testing.
+func RandomLorawanUnconfirmedDownlink() *DownlinkMessage {
+	msg := randomDownlinkMessage()
+	msg.Payload = lorawan.RandomPayload(lorawan.MType_UNCONFIRMED_DOWN)
+	return msg
+}
+
+// RandomLorawanDownlinkMessage returns randomly generated lorawan downlink message(join request, confirmed or unconfirmed downlink).
+// Used for testing.
+func RandomLorawanDownlinkMessage() *DownlinkMessage {
+	switch rand.Intn(3) {
+	case 0:
+		return RandomLorawanJoinAccept()
+	case 1:
+		return RandomLorawanConfirmedDownlink()
+	default:
+		return RandomLorawanUnconfirmedDownlink()
+	}
+}
+
+// RandomDeduplicatedUplinkMessage returns randomly generated uplink message.
+// Used for testing.
+func RandomDeduplicatedUplinkMessage() *DeduplicatedUplinkMessage {
+	return RandomLorawanDeduplicatedUplinkMessage()
+}
+
+// RandomDownlinkMessage returns randomly generated downlink message.
+// Used for testing.
+func RandomDownlinkMessage() *DownlinkMessage {
+	return RandomLorawanDownlinkMessage()
+}

--- a/api/broker/random_test.go
+++ b/api/broker/random_test.go
@@ -1,0 +1,46 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package broker
+
+import (
+	"testing"
+
+	"github.com/TheThingsNetwork/ttn/api"
+	s "github.com/smartystreets/assertions"
+)
+
+type PayloadUnmarshaller interface {
+	UnmarshalPayload() error
+}
+
+func TestRandomizers(t *testing.T) {
+	for name, msg := range map[string]interface{}{
+		"RandomLorawanConfirmedDeduplicatedUplink()":   RandomLorawanConfirmedDeduplicatedUplink(),
+		"RandomLorawanUnconfirmedDeduplicatedUplink()": RandomLorawanUnconfirmedDeduplicatedUplink(),
+		"RandomLorawanDeduplicatedJoinRequest()":       RandomLorawanDeduplicatedJoinRequest(),
+		"RandomLorawanDeduplicatedUplinkMessage()":     RandomLorawanDeduplicatedUplinkMessage(),
+		"RandomDeduplicatedUplinkMessage()":            RandomDeduplicatedUplinkMessage(),
+
+		"RandomLorawanConfirmedDownlink()":   RandomLorawanConfirmedDownlink(),
+		"RandomLorawanUnconfirmedDownlink()": RandomLorawanUnconfirmedDownlink(),
+		"RandomLorawanJoinAccept()":          RandomLorawanJoinAccept(),
+		"RandomLorawanDownlinkMessage()":     RandomLorawanDownlinkMessage(),
+		"RandomDownlinkMessage()":            RandomDownlinkMessage(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if v, ok := msg.(api.Validator); ok {
+				t.Run("Validate", func(t *testing.T) {
+					a := s.New(t)
+					a.So(v.Validate(), s.ShouldBeNil)
+				})
+			}
+			if v, ok := msg.(PayloadUnmarshaller); ok {
+				t.Run("UnmarshalPayload", func(t *testing.T) {
+					a := s.New(t)
+					a.So(v.UnmarshalPayload(), s.ShouldBeNil)
+				})
+			}
+		})
+	}
+}

--- a/utils/random/random.go
+++ b/utils/random/random.go
@@ -6,6 +6,7 @@ package random
 import (
 	"fmt"
 	"math"
+	"strings"
 	"time"
 
 	"github.com/TheThingsNetwork/go-utils/pseudorandom"
@@ -27,14 +28,50 @@ func New() *TTNRandom {
 
 var global = New()
 
+func (r *TTNRandom) randomChar() byte {
+	return byte('a' + r.Intn('z'-'a'))
+}
+func (r *TTNRandom) randomCharString() string {
+	return string(r.randomChar())
+}
+
+func (r *TTNRandom) formatID(s string) string {
+	switch {
+	case strings.HasPrefix(s, "-"):
+		s = strings.TrimPrefix(s, "-") + r.randomCharString()
+	case strings.HasPrefix(s, "_"):
+		s = strings.TrimPrefix(s, "_") + r.randomCharString()
+	case strings.HasSuffix(s, "-"):
+		s = strings.TrimSuffix(s, "-") + r.randomCharString()
+	case strings.HasSuffix(s, "_"):
+		s = strings.TrimSuffix(s, "_") + r.randomCharString()
+	}
+	return strings.ToLower(strings.NewReplacer(
+		"_-", r.randomCharString()+r.randomCharString(),
+		"-_", r.randomCharString()+r.randomCharString(),
+		"__", r.randomCharString()+r.randomCharString(),
+		"--", r.randomCharString()+r.randomCharString(),
+	).Replace(s))
+}
+
 // ID returns randomly generated ID
 func (r *TTNRandom) ID() string {
-	return r.Interface.String(2 + r.Interface.Intn(61))
+	return r.formatID(r.Interface.String(2 + r.Interface.Intn(61)))
+}
+
+// AppID returns randomly generated AppID
+func (r *TTNRandom) AppID() string {
+	return r.formatID(r.Interface.String(2 + r.Interface.Intn(34)))
+}
+
+// DevID returns randomly generated DevID
+func (r *TTNRandom) DevID() string {
+	return r.formatID(r.Interface.String(2 + r.Interface.Intn(34)))
 }
 
 // Bool return randomly generated bool value
 func (r *TTNRandom) Bool() bool {
-	return r.Interface.Intn(1) == 0
+	return r.Interface.Intn(2) == 0
 }
 
 // Rssi generates RSSI signal between -120 < rssi < 0
@@ -174,6 +211,12 @@ func Bool() bool {
 
 func ID() string {
 	return global.ID()
+}
+func AppID() string {
+	return global.AppID()
+}
+func DevID() string {
+	return global.DevID()
 }
 
 func DevNonce() types.DevNonce {


### PR DESCRIPTION
- adds random broker message generators
- fixes bug where `rand.Bool` always returns `true`
- makes sure random `id` generators produce correct `id`s