### PR TITLE
Fix handling of MAC-only Downlink (#570)

### DIFF
--- a/api/protocol/lorawan/message_conversion.go
+++ b/api/protocol/lorawan/message_conversion.go
@@ -54,12 +54,16 @@ func (msg *Message_MacPayload) Payload() lorawan.Payload {
 	for _, cmd := range m.FOpts {
 		mac.FHDR.FOpts = append(mac.FHDR.FOpts, cmd.MACCommand())
 	}
-	if m.FPort >= 0 {
+	if m.FPort > 0 {
 		fPort := uint8(m.FPort)
 		mac.FPort = &fPort
 	}
-	mac.FRMPayload = []lorawan.Payload{
-		&lorawan.DataPayload{Bytes: m.FrmPayload},
+	if len(m.FrmPayload) != 0 {
+		mac.FRMPayload = []lorawan.Payload{&lorawan.DataPayload{Bytes: m.FrmPayload}}
+		if mac.FPort == nil {
+			fPort := uint8(0)
+			mac.FPort = &fPort
+		}
 	}
 	return &mac
 }

--- a/api/protocol/lorawan/util.go
+++ b/api/protocol/lorawan/util.go
@@ -68,7 +68,10 @@ func (m *Message) cryptFRMPayload(appSKey types.AppSKey) error {
 	if err := phy.DecryptFRMPayload(lorawan.AES128Key(appSKey)); err != nil {
 		return err
 	}
-	*m = MessageFromPHYPayload(phy)
+	crypted := MessageFromPHYPayload(phy)
+	if m.GetMacPayload() != nil && crypted.GetMacPayload() != nil {
+		m.GetMacPayload().FrmPayload = crypted.GetMacPayload().FrmPayload
+	}
 	return nil
 }
 

--- a/core/handler/convert_lorawan.go
+++ b/core/handler/convert_lorawan.go
@@ -6,74 +6,57 @@ package handler
 import (
 	ttnlog "github.com/TheThingsNetwork/go-utils/log"
 	pb_broker "github.com/TheThingsNetwork/ttn/api/broker"
+	pb_lorawan "github.com/TheThingsNetwork/ttn/api/protocol/lorawan"
 	"github.com/TheThingsNetwork/ttn/api/trace"
 	"github.com/TheThingsNetwork/ttn/core/handler/device"
 	"github.com/TheThingsNetwork/ttn/core/types"
 	"github.com/TheThingsNetwork/ttn/utils/errors"
-	"github.com/TheThingsNetwork/ttn/utils/pointer"
-	"github.com/brocaar/lorawan"
 )
 
-func (h *handler) ConvertFromLoRaWAN(ctx ttnlog.Interface, ttnUp *pb_broker.DeduplicatedUplinkMessage, appUp *types.UplinkMessage, dev *device.Device) error {
-	// Check for LoRaWAN
-	if lorawan := ttnUp.ProtocolMetadata.GetLorawan(); lorawan == nil {
-		return errors.NewErrInvalidArgument("Uplink", "does not contain LoRaWAN metadata")
-	}
-
-	// LoRaWAN: Unmarshal Uplink
-	var phyPayload lorawan.PHYPayload
-	err := phyPayload.UnmarshalBinary(ttnUp.Payload)
-	if err != nil {
+func (h *handler) ConvertFromLoRaWAN(ctx ttnlog.Interface, ttnUp *pb_broker.DeduplicatedUplinkMessage, appUp *types.UplinkMessage, dev *device.Device) (err error) {
+	if err := ttnUp.UnmarshalPayload(); err != nil {
 		return err
 	}
-	macPayload, ok := phyPayload.MACPayload.(*lorawan.MACPayload)
-	if !ok {
+	if ttnUp.GetMessage().GetLorawan() == nil {
+		return errors.NewErrInvalidArgument("Uplink", "does not contain a LoRaWAN payload")
+	}
+
+	phyPayload := ttnUp.GetMessage().GetLorawan()
+	macPayload := phyPayload.GetMacPayload()
+	if macPayload == nil {
 		return errors.NewErrInvalidArgument("Uplink", "does not contain a MAC payload")
 	}
 
-	// LoRaWAN: Validate MIC
-	macPayload.FHDR.FCnt = ttnUp.ProtocolMetadata.GetLorawan().FCnt
 	ttnUp.Trace = ttnUp.Trace.WithEvent(trace.CheckMICEvent)
-	ok, err = phyPayload.ValidateMIC(lorawan.AES128Key(dev.NwkSKey))
+	err = phyPayload.ValidateMIC(dev.NwkSKey)
 	if err != nil {
 		return err
 	}
-	if !ok {
-		return errors.NewErrNotFound("device that validates MIC")
-	}
 
 	appUp.HardwareSerial = dev.DevEUI.String()
-	appUp.FCnt = macPayload.FHDR.FCnt
-	ctx = ctx.WithField("FCnt", appUp.FCnt)
+
+	appUp.FCnt = macPayload.FCnt
 	if dev.FCntUp == appUp.FCnt {
 		appUp.IsRetry = true
 	}
-	if phyPayload.MHDR.MType == lorawan.ConfirmedDataUp {
-		appUp.Confirmed = true
-	}
 	dev.FCntUp = appUp.FCnt
 
-	// LoRaWAN: Decrypt
-	if macPayload.FPort != nil {
-		appUp.FPort = *macPayload.FPort
-		if *macPayload.FPort != 0 && len(macPayload.FRMPayload) == 1 {
-			ctx = ctx.WithField("FCnt", appUp.FPort)
-			if err := phyPayload.DecryptFRMPayload(lorawan.AES128Key(dev.AppSKey)); err != nil {
-				return errors.NewErrInternal("Could not decrypt payload")
-			}
-			payload, ok := macPayload.FRMPayload[0].(*lorawan.DataPayload)
-			if !ok {
-				return errors.NewErrInvalidArgument("Uplink FRMPayload", "must be of type *lorawan.DataPayload")
-			}
-			appUp.PayloadRaw = payload.Bytes
+	if phyPayload.MType == pb_lorawan.MType_CONFIRMED_UP {
+		appUp.Confirmed = true
+	}
+
+	if macPayload.FPort > 0 {
+		if err := phyPayload.DecryptFRMPayload(dev.AppSKey); err != nil {
+			return errors.NewErrInternal("Could not decrypt payload")
 		}
+		appUp.PayloadRaw = macPayload.FrmPayload
 	}
 
 	if dev.CurrentDownlink != nil && !appUp.IsRetry {
 		// We have a downlink pending
 		if dev.CurrentDownlink.Confirmed {
 			// If it's confirmed, we can only unset it if we receive an ack.
-			if macPayload.FHDR.FCtrl.ACK {
+			if macPayload.Ack {
 				// Send event over MQTT
 				h.qEvent <- &types.DeviceEvent{
 					AppID: appUp.AppID,
@@ -94,72 +77,63 @@ func (h *handler) ConvertFromLoRaWAN(ctx ttnlog.Interface, ttnUp *pb_broker.Dedu
 	return nil
 }
 
-func (h *handler) ConvertToLoRaWAN(ctx ttnlog.Interface, appDown *types.DownlinkMessage, ttnDown *pb_broker.DownlinkMessage, dev *device.Device) error {
-	// LoRaWAN: Unmarshal Downlink
-	var phyPayload lorawan.PHYPayload
-	err := phyPayload.UnmarshalBinary(ttnDown.Payload)
-	if err != nil {
+func (h *handler) ConvertToLoRaWAN(ctx ttnlog.Interface, appDown *types.DownlinkMessage, ttnDown *pb_broker.DownlinkMessage, dev *device.Device) (err error) {
+	if err := ttnDown.UnmarshalPayload(); err != nil {
 		return err
 	}
-	macPayload, ok := phyPayload.MACPayload.(*lorawan.MACPayload)
-	if !ok {
-		return errors.NewErrInvalidArgument("Downlink", "does not contain a MAC payload")
+	if ttnDown.GetMessage().GetLorawan() == nil {
+		return errors.NewErrInvalidArgument("Downlink", "does not contain a LoRaWAN payload")
 	}
-	if ttnDown.DownlinkOption != nil && ttnDown.DownlinkOption.ProtocolConfig.GetLorawan() != nil {
-		macPayload.FHDR.FCnt = ttnDown.DownlinkOption.ProtocolConfig.GetLorawan().FCnt
+
+	phyPayload := ttnDown.GetMessage().GetLorawan()
+	macPayload := phyPayload.GetMacPayload()
+	if macPayload == nil {
+		return errors.NewErrInvalidArgument("Downlink", "does not contain a MAC payload")
 	}
 
 	// Abort when downlink not needed
-	if len(appDown.PayloadRaw) == 0 && !macPayload.FHDR.FCtrl.ACK && len(macPayload.FHDR.FOpts) == 0 {
+	if len(appDown.PayloadRaw) == 0 && !macPayload.Ack && len(macPayload.FOpts) == 0 {
 		return ErrNotNeeded
 	}
 
-	// Set FPort
-	if appDown.FPort != 0 {
-		macPayload.FPort = &appDown.FPort
+	if appDown.FPort > 0 {
+		macPayload.FPort = int32(appDown.FPort)
 	}
 
 	if appDown.Confirmed {
-		phyPayload.MHDR.MType = lorawan.ConfirmedDataDown
+		phyPayload.MType = pb_lorawan.MType_CONFIRMED_DOWN
 	}
 
 	if queue, err := h.devices.DownlinkQueue(dev.AppID, dev.DevID); err == nil {
 		if length, _ := queue.Length(); length > 0 {
-			macPayload.FHDR.FCtrl.FPending = true
+			macPayload.FPending = true
 		}
 	}
 
 	// Set Payload
 	if len(appDown.PayloadRaw) > 0 {
 		ttnDown.Trace = ttnDown.Trace.WithEvent("set payload")
-		macPayload.FRMPayload = []lorawan.Payload{&lorawan.DataPayload{Bytes: appDown.PayloadRaw}}
-		if macPayload.FPort == nil || *macPayload.FPort == 0 {
-			macPayload.FPort = pointer.Uint8(1)
+		macPayload.FrmPayload = appDown.PayloadRaw
+		if macPayload.FPort <= 0 {
+			macPayload.FPort = 1
+		}
+		err = phyPayload.EncryptFRMPayload(dev.AppSKey)
+		if err != nil {
+			return err
 		}
 	} else {
 		ttnDown.Trace = ttnDown.Trace.WithEvent("set empty payload")
-		macPayload.FRMPayload = []lorawan.Payload{}
-	}
-
-	// Encrypt
-	err = phyPayload.EncryptFRMPayload(lorawan.AES128Key(dev.AppSKey))
-	if err != nil {
-		return err
+		macPayload.FrmPayload = []byte{}
+		macPayload.FPort = 0
 	}
 
 	// Set MIC
-	err = phyPayload.SetMIC(lorawan.AES128Key(dev.NwkSKey))
+	err = phyPayload.SetMIC(dev.NwkSKey)
 	if err != nil {
 		return err
 	}
 
-	// Marshal
-	phyPayloadBytes, err := phyPayload.MarshalBinary()
-	if err != nil {
-		return err
-	}
-
-	ttnDown.Payload = phyPayloadBytes
+	ttnDown.Payload = phyPayload.PHYPayloadBytes()
 
 	return nil
 }

--- a/core/handler/convert_lorawan_test.go
+++ b/core/handler/convert_lorawan_test.go
@@ -93,7 +93,7 @@ func buildLorawanDownlink(payload []byte) (*types.DownlinkMessage, *pb_broker.Do
 	appDown := &types.DownlinkMessage{
 		DevID:      "devid",
 		AppID:      "appid",
-		PayloadRaw: []byte{0xaa, 0xbc},
+		PayloadRaw: payload,
 	}
 	ttnDown := &pb_broker.DownlinkMessage{
 		Payload: []byte{96, 4, 3, 2, 1, 0, 1, 0, 1, 0, 0, 0, 0},

--- a/core/handler/convert_lorawan_test.go
+++ b/core/handler/convert_lorawan_test.go
@@ -128,4 +128,14 @@ func TestConvertToLoRaWAN(t *testing.T) {
 	err = h.ConvertToLoRaWAN(h.Ctx, appDown, ttnDown, device)
 	a.So(err, ShouldBeNil)
 	a.So(ttnDown.Payload, ShouldResemble, []byte{0x60, 0x04, 0x03, 0x02, 0x01, 0x00, 0x01, 0x00, 0x08, 0xa1, 0x33, 0x41, 0xA9, 0xFA, 0x03})
+
+	appDown, ttnDown = buildLorawanDownlink([]byte{})
+	appDown.FPort = 0
+	ttnDown.UnmarshalPayload()
+	ttnDown.GetMessage().GetLorawan().GetMacPayload().Ack = true
+	ttnDown.Payload = ttnDown.GetMessage().GetLorawan().PHYPayloadBytes()
+
+	err = h.ConvertToLoRaWAN(h.Ctx, appDown, ttnDown, device)
+	a.So(err, ShouldBeNil)
+	a.So(ttnDown.Payload, ShouldResemble, []byte{0x60, 0x04, 0x03, 0x02, 0x01, 0x20, 0x01, 0x00, 0x94, 0xf8, 0xcf, 0x0d})
 }

--- a/core/handler/downlink_test.go
+++ b/core/handler/downlink_test.go
@@ -109,14 +109,16 @@ func TestHandleDownlink(t *testing.T) {
 		qEvent:       make(chan *types.DeviceEvent, 10),
 	}
 	h.InitStatus()
+
+	downlink := pb_broker.RandomDownlinkMessage()
+	downlink.AppEui = &appEUI
+	downlink.DevEui = &devEUI
+
 	// Neither payload nor Fields provided : ERROR
 	err = h.HandleDownlink(&types.DownlinkMessage{
 		AppID: appID,
 		DevID: devID,
-	}, &pb_broker.DownlinkMessage{
-		AppEui: &appEUI,
-		DevEui: &devEUI,
-	})
+	}, downlink)
 	a.So(err, ShouldNotBeNil)
 
 	h.devices.Set(&device.Device{
@@ -126,14 +128,12 @@ func TestHandleDownlink(t *testing.T) {
 	defer func() {
 		h.devices.Delete(appID, devID)
 	}()
+
+	downlink.Payload = []byte{96, 4, 3, 2, 1, 0, 1, 0, 1, 0, 0, 0, 0}
 	err = h.HandleDownlink(&types.DownlinkMessage{
 		AppID: appID,
 		DevID: devID,
-	}, &pb_broker.DownlinkMessage{
-		AppEui:  &appEUI,
-		DevEui:  &devEUI,
-		Payload: []byte{96, 4, 3, 2, 1, 0, 1, 0, 1, 0, 0, 0, 0},
-	})
+	}, downlink)
 	a.So(err, ShouldBeNil)
 
 	// Payload provided
@@ -143,16 +143,12 @@ func TestHandleDownlink(t *testing.T) {
 		a.So(dl.Payload, ShouldNotBeEmpty)
 		wg.Done()
 	}()
+
 	err = h.HandleDownlink(&types.DownlinkMessage{
 		AppID:      appID,
 		DevID:      devID,
 		PayloadRaw: []byte{0xAA, 0xBC},
-	}, &pb_broker.DownlinkMessage{
-		AppEui:         &appEUI,
-		DevEui:         &devEUI,
-		Payload:        []byte{96, 4, 3, 2, 1, 0, 1, 0, 1, 0, 0, 0, 0},
-		DownlinkOption: &pb_broker.DownlinkOption{},
-	})
+	}, downlink)
 	a.So(err, ShouldBeNil)
 	wg.WaitFor(100 * time.Millisecond)
 
@@ -167,17 +163,14 @@ func TestHandleDownlink(t *testing.T) {
 		h.applications.Delete(appID)
 	}()
 	jsonFields := map[string]interface{}{"temperature": 11}
+
 	err = h.HandleDownlink(&types.DownlinkMessage{
 		FPort:         1,
 		AppID:         appID,
 		DevID:         devID,
 		PayloadFields: jsonFields,
 		PayloadRaw:    []byte{0xAA, 0xBC},
-	}, &pb_broker.DownlinkMessage{
-		AppEui:  &appEUI,
-		DevEui:  &devEUI,
-		Payload: []byte{96, 4, 3, 2, 1, 0, 1, 0, 1, 0, 0, 0, 0},
-	})
+	}, downlink)
 	a.So(err, ShouldNotBeNil)
 
 	// JSON Fields provided
@@ -192,12 +185,7 @@ func TestHandleDownlink(t *testing.T) {
 		AppID:         appID,
 		DevID:         devID,
 		PayloadFields: jsonFields,
-	}, &pb_broker.DownlinkMessage{
-		AppEui:         &appEUI,
-		DevEui:         &devEUI,
-		Payload:        []byte{96, 4, 3, 2, 1, 0, 1, 0, 1, 0, 0, 0, 0},
-		DownlinkOption: &pb_broker.DownlinkOption{},
-	})
+	}, downlink)
 	a.So(err, ShouldBeNil)
 	wg.WaitFor(100 * time.Millisecond)
 }

--- a/core/handler/uplink_test.go
+++ b/core/handler/uplink_test.go
@@ -52,8 +52,6 @@ func TestHandleUplink(t *testing.T) {
 	h.qEvent = make(chan *types.DeviceEvent, 10)
 	h.downlink = make(chan *pb_broker.DownlinkMessage)
 
-	uplink, _ := buildLorawanUplink([]byte{0x40, 0x04, 0x03, 0x02, 0x01, 0x00, 0x01, 0x00, 0x0A, 0x4D, 0xDA, 0x23, 0x99, 0x61, 0xD4})
-
 	downlinkEmpty := []byte{0x60, 0x04, 0x03, 0x02, 0x01, 0x00, 0x00, 0x00, 0x0A, 0x21, 0xEA, 0x8B, 0x0E}
 	downlinkACK := []byte{0x60, 0x04, 0x03, 0x02, 0x01, 0x20, 0x00, 0x00, 0x0A, 0x3B, 0x3F, 0x77, 0x0B}
 	downlinkMAC := []byte{0x60, 0x04, 0x03, 0x02, 0x01, 0x05, 0x00, 0x00, 0x03, 0x30, 0x00, 0x00, 0x00, 0x0A, 0x4D, 0x11, 0x55, 0x01}
@@ -67,78 +65,94 @@ func TestHandleUplink(t *testing.T) {
 		},
 	}
 
-	// Test Uplink, no downlink option available
-	wg.Add(1)
-	go func() {
-		<-h.qUp
-		wg.Done()
-	}()
-	err = h.HandleUplink(uplink)
-	a.So(err, ShouldBeNil)
-	wg.WaitFor(50 * time.Millisecond)
+	getUplink := func() *pb_broker.DeduplicatedUplinkMessage {
+		uplink, _ := buildLorawanUplink([]byte{0x40, 0x04, 0x03, 0x02, 0x01, 0x00, 0x01, 0x00, 0x0A, 0x4D, 0xDA, 0x23, 0x99, 0x61, 0xD4})
+		uplink.ResponseTemplate = downlink
+		return uplink
+	}
 
-	uplink.ResponseTemplate = downlink
+	// Test Uplink, no downlink option available
+	{
+		wg.Add(1)
+		go func() {
+			<-h.qUp
+			wg.Done()
+		}()
+		uplink := getUplink()
+		uplink.ResponseTemplate = nil
+		err = h.HandleUplink(uplink)
+		a.So(err, ShouldBeNil)
+		wg.WaitFor(50 * time.Millisecond)
+	}
 
 	// Test Uplink, no downlink needed
-	wg.Add(1)
-	go func() {
-		<-h.qUp
-		wg.Done()
-	}()
-	downlink.Payload = downlinkEmpty
-	err = h.HandleUplink(uplink)
-	a.So(err, ShouldBeNil)
-	wg.WaitFor(50 * time.Millisecond)
+	{
+		wg.Add(1)
+		go func() {
+			<-h.qUp
+			wg.Done()
+		}()
+		downlink.Payload = downlinkEmpty
+		err = h.HandleUplink(getUplink())
+		a.So(err, ShouldBeNil)
+		wg.WaitFor(50 * time.Millisecond)
+	}
 
 	// Test Uplink, ACK downlink needed
-	wg.Add(2)
-	go func() {
-		<-h.qUp
-		wg.Done()
-	}()
-	go func() {
-		<-h.downlink
-		wg.Done()
-	}()
-	downlink.Payload = downlinkACK
-	err = h.HandleUplink(uplink)
-	a.So(err, ShouldBeNil)
-	wg.WaitFor(50 * time.Millisecond)
+	{
+		wg.Add(2)
+		go func() {
+			<-h.qUp
+			wg.Done()
+		}()
+		go func() {
+			<-h.downlink
+			wg.Done()
+		}()
+		downlink.Payload = downlinkACK
+		err = h.HandleUplink(getUplink())
+		a.So(err, ShouldBeNil)
+		wg.WaitFor(50 * time.Millisecond)
+	}
 
 	// Test Uplink, MAC downlink needed
-	wg.Add(2)
-	go func() {
-		<-h.qUp
-		wg.Done()
-	}()
-	go func() {
-		<-h.downlink
-		wg.Done()
-	}()
-	downlink.Payload = downlinkMAC
-	err = h.HandleUplink(uplink)
-	a.So(err, ShouldBeNil)
-	wg.WaitFor(50 * time.Millisecond)
+	{
+		wg.Add(2)
+		go func() {
+			<-h.qUp
+			wg.Done()
+		}()
+		go func() {
+			<-h.downlink
+			wg.Done()
+		}()
+		downlink.Payload = downlinkMAC
+		err = h.HandleUplink(getUplink())
+		a.So(err, ShouldBeNil)
+		wg.WaitFor(50 * time.Millisecond)
+	}
 
 	queue, _ := h.devices.DownlinkQueue(appID, devID)
 	queue.PushFirst(&types.DownlinkMessage{PayloadRaw: []byte{0xaa, 0xbc}})
 
 	// Test Uplink, Data downlink needed
-	h.devices.Set(dev)
-	wg.Add(2)
-	go func() {
-		<-h.qUp
-		wg.Done()
-	}()
-	go func() {
-		dl := <-h.downlink
-		a.So(dl.Payload, ShouldResemble, expected)
-		wg.Done()
-	}()
-	downlink.Payload = downlinkEmpty
-	err = h.HandleUplink(uplink)
-	a.So(err, ShouldBeNil)
-	wg.WaitFor(50 * time.Millisecond)
+	{
+		h.devices.Set(dev)
+		wg.Add(2)
+		go func() {
+			<-h.qUp
+			wg.Done()
+		}()
+		go func() {
+			dl := <-h.downlink
+			a.So(dl.Payload, ShouldResemble, expected)
+			wg.Done()
+		}()
+		downlink.Payload = downlinkEmpty
+		err = h.HandleUplink(getUplink())
+		a.So(err, ShouldBeNil)
+		wg.WaitFor(50 * time.Millisecond)
+	}
 
 	dev, _ = h.devices.Get(appID, devID)
 	qLen, _ := queue.Length()
@@ -151,21 +165,23 @@ func TestHandleUplink(t *testing.T) {
 	queue.PushFirst(&types.DownlinkMessage{PayloadRaw: []byte{0x12, 0x34}})
 
 	// Test Uplink, Data downlink needed
-	h.devices.Set(dev)
-	wg.Add(2)
-	go func() {
-		<-h.qUp
-		wg.Done()
-	}()
-	go func() {
-		dl := <-h.downlink
-		a.So(dl.Payload, ShouldResemble, []byte{160, 4, 3, 2, 1, 16, 0, 0, 10, 102, 230, 154, 218, 17, 187}) // The confirmed downlink with FPending on
-		wg.Done()
-	}()
-	downlink.Payload = downlinkEmpty
-	err = h.HandleUplink(uplink)
-	a.So(err, ShouldBeNil)
-	wg.WaitFor(50 * time.Millisecond)
+	{
+		h.devices.Set(dev)
+		wg.Add(2)
+		go func() {
+			<-h.qUp
+			wg.Done()
+		}()
+		go func() {
+			dl := <-h.downlink
+			a.So(dl.Payload, ShouldResemble, []byte{160, 4, 3, 2, 1, 16, 0, 0, 10, 102, 230, 154, 218, 17, 187}) // The confirmed downlink with FPending on
+			wg.Done()
+		}()
+		downlink.Payload = downlinkEmpty
+		err = h.HandleUplink(getUplink())
+		a.So(err, ShouldBeNil)
+		wg.WaitFor(50 * time.Millisecond)
+	}
 
 	dev, _ = h.devices.Get(appID, devID)
 	next, _ := queue.Next()


### PR DESCRIPTION
This PR ensures that MAC-only downlinks (empty FRMPayload) do not contain an FPort field.

This PR additionally includes:
- a refactor of LoRaWAN conversion in the Handler
- a small change in LoRaWAN-Protobuf conversion that keeps pointers intact

Note that this PR focuses on the Handler (application layer) and therefore does **not** add support for encrypted MAC commands (in FRMPayload, port 0)