### PR TITLE
Add component status streams to monitor proto

### DIFF
--- a/api/monitor/monitor.pb.go
+++ b/api/monitor/monitor.pb.go
@@ -18,6 +18,8 @@ import math "math"
 import gateway "github.com/TheThingsNetwork/ttn/api/gateway"
 import router "github.com/TheThingsNetwork/ttn/api/router"
 import broker "github.com/TheThingsNetwork/ttn/api/broker"
+import handler "github.com/TheThingsNetwork/ttn/api/handler"
+import networkserver "github.com/TheThingsNetwork/ttn/api/networkserver"
 import google_protobuf1 "github.com/golang/protobuf/ptypes/empty"
 
 import (
@@ -47,13 +49,17 @@ const _ = grpc.SupportPackageIsVersion4
 // Client API for Monitor service
 
 type MonitorClient interface {
+	RouterStatus(ctx context.Context, opts ...grpc.CallOption) (Monitor_RouterStatusClient, error)
 	GatewayStatus(ctx context.Context, opts ...grpc.CallOption) (Monitor_GatewayStatusClient, error)
 	GatewayUplink(ctx context.Context, opts ...grpc.CallOption) (Monitor_GatewayUplinkClient, error)
 	GatewayDownlink(ctx context.Context, opts ...grpc.CallOption) (Monitor_GatewayDownlinkClient, error)
+	BrokerStatus(ctx context.Context, opts ...grpc.CallOption) (Monitor_BrokerStatusClient, error)
 	BrokerUplink(ctx context.Context, opts ...grpc.CallOption) (Monitor_BrokerUplinkClient, error)
 	BrokerDownlink(ctx context.Context, opts ...grpc.CallOption) (Monitor_BrokerDownlinkClient, error)
+	HandlerStatus(ctx context.Context, opts ...grpc.CallOption) (Monitor_HandlerStatusClient, error)
 	HandlerUplink(ctx context.Context, opts ...grpc.CallOption) (Monitor_HandlerUplinkClient, error)
 	HandlerDownlink(ctx context.Context, opts ...grpc.CallOption) (Monitor_HandlerDownlinkClient, error)
+	NetworkServerStatus(ctx context.Context, opts ...grpc.CallOption) (Monitor_NetworkServerStatusClient, error)
 }
 
 type monitorClient struct {
@@ -64,8 +70,42 @@ func NewMonitorClient(cc *grpc.ClientConn) MonitorClient {
 	return &monitorClient{cc}
 }
 
+func (c *monitorClient) RouterStatus(ctx context.Context, opts ...grpc.CallOption) (Monitor_RouterStatusClient, error) {
+	stream, err := grpc.NewClientStream(ctx, &_Monitor_serviceDesc.Streams[0], c.cc, "/monitor.Monitor/RouterStatus", opts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &monitorRouterStatusClient{stream}
+	return x, nil
+}
+
+type Monitor_RouterStatusClient interface {
+	Send(*router.Status) error
+	CloseAndRecv() (*google_protobuf1.Empty, error)
+	grpc.ClientStream
+}
+
+type monitorRouterStatusClient struct {
+	grpc.ClientStream
+}
+
+func (x *monitorRouterStatusClient) Send(m *router.Status) error {
+	return x.ClientStream.SendMsg(m)
+}
+
+func (x *monitorRouterStatusClient) CloseAndRecv() (*google_protobuf1.Empty, error) {
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	m := new(google_protobuf1.Empty)
+	if err := x.ClientStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
 func (c *monitorClient) GatewayStatus(ctx context.Context, opts ...grpc.CallOption) (Monitor_GatewayStatusClient, error) {
-	stream, err := grpc.NewClientStream(ctx, &_Monitor_serviceDesc.Streams[0], c.cc, "/monitor.Monitor/GatewayStatus", opts...)
+	stream, err := grpc.NewClientStream(ctx, &_Monitor_serviceDesc.Streams[1], c.cc, "/monitor.Monitor/GatewayStatus", opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +139,7 @@ func (x *monitorGatewayStatusClient) CloseAndRecv() (*google_protobuf1.Empty, er
 }
 
 func (c *monitorClient) GatewayUplink(ctx context.Context, opts ...grpc.CallOption) (Monitor_GatewayUplinkClient, error) {
-	stream, err := grpc.NewClientStream(ctx, &_Monitor_serviceDesc.Streams[1], c.cc, "/monitor.Monitor/GatewayUplink", opts...)
+	stream, err := grpc.NewClientStream(ctx, &_Monitor_serviceDesc.Streams[2], c.cc, "/monitor.Monitor/GatewayUplink", opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +173,7 @@ func (x *monitorGatewayUplinkClient) CloseAndRecv() (*google_protobuf1.Empty, er
 }
 
 func (c *monitorClient) GatewayDownlink(ctx context.Context, opts ...grpc.CallOption) (Monitor_GatewayDownlinkClient, error) {
-	stream, err := grpc.NewClientStream(ctx, &_Monitor_serviceDesc.Streams[2], c.cc, "/monitor.Monitor/GatewayDownlink", opts...)
+	stream, err := grpc.NewClientStream(ctx, &_Monitor_serviceDesc.Streams[3], c.cc, "/monitor.Monitor/GatewayDownlink", opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -166,8 +206,42 @@ func (x *monitorGatewayDownlinkClient) CloseAndRecv() (*google_protobuf1.Empty, 
 	return m, nil
 }
 
+func (c *monitorClient) BrokerStatus(ctx context.Context, opts ...grpc.CallOption) (Monitor_BrokerStatusClient, error) {
+	stream, err := grpc.NewClientStream(ctx, &_Monitor_serviceDesc.Streams[4], c.cc, "/monitor.Monitor/BrokerStatus", opts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &monitorBrokerStatusClient{stream}
+	return x, nil
+}
+
+type Monitor_BrokerStatusClient interface {
+	Send(*broker.Status) error
+	CloseAndRecv() (*google_protobuf1.Empty, error)
+	grpc.ClientStream
+}
+
+type monitorBrokerStatusClient struct {
+	grpc.ClientStream
+}
+
+func (x *monitorBrokerStatusClient) Send(m *broker.Status) error {
+	return x.ClientStream.SendMsg(m)
+}
+
+func (x *monitorBrokerStatusClient) CloseAndRecv() (*google_protobuf1.Empty, error) {
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	m := new(google_protobuf1.Empty)
+	if err := x.ClientStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
 func (c *monitorClient) BrokerUplink(ctx context.Context, opts ...grpc.CallOption) (Monitor_BrokerUplinkClient, error) {
-	stream, err := grpc.NewClientStream(ctx, &_Monitor_serviceDesc.Streams[3], c.cc, "/monitor.Monitor/BrokerUplink", opts...)
+	stream, err := grpc.NewClientStream(ctx, &_Monitor_serviceDesc.Streams[5], c.cc, "/monitor.Monitor/BrokerUplink", opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +275,7 @@ func (x *monitorBrokerUplinkClient) CloseAndRecv() (*google_protobuf1.Empty, err
 }
 
 func (c *monitorClient) BrokerDownlink(ctx context.Context, opts ...grpc.CallOption) (Monitor_BrokerDownlinkClient, error) {
-	stream, err := grpc.NewClientStream(ctx, &_Monitor_serviceDesc.Streams[4], c.cc, "/monitor.Monitor/BrokerDownlink", opts...)
+	stream, err := grpc.NewClientStream(ctx, &_Monitor_serviceDesc.Streams[6], c.cc, "/monitor.Monitor/BrokerDownlink", opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -234,8 +308,42 @@ func (x *monitorBrokerDownlinkClient) CloseAndRecv() (*google_protobuf1.Empty, e
 	return m, nil
 }
 
+func (c *monitorClient) HandlerStatus(ctx context.Context, opts ...grpc.CallOption) (Monitor_HandlerStatusClient, error) {
+	stream, err := grpc.NewClientStream(ctx, &_Monitor_serviceDesc.Streams[7], c.cc, "/monitor.Monitor/HandlerStatus", opts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &monitorHandlerStatusClient{stream}
+	return x, nil
+}
+
+type Monitor_HandlerStatusClient interface {
+	Send(*handler.Status) error
+	CloseAndRecv() (*google_protobuf1.Empty, error)
+	grpc.ClientStream
+}
+
+type monitorHandlerStatusClient struct {
+	grpc.ClientStream
+}
+
+func (x *monitorHandlerStatusClient) Send(m *handler.Status) error {
+	return x.ClientStream.SendMsg(m)
+}
+
+func (x *monitorHandlerStatusClient) CloseAndRecv() (*google_protobuf1.Empty, error) {
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	m := new(google_protobuf1.Empty)
+	if err := x.ClientStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
 func (c *monitorClient) HandlerUplink(ctx context.Context, opts ...grpc.CallOption) (Monitor_HandlerUplinkClient, error) {
-	stream, err := grpc.NewClientStream(ctx, &_Monitor_serviceDesc.Streams[5], c.cc, "/monitor.Monitor/HandlerUplink", opts...)
+	stream, err := grpc.NewClientStream(ctx, &_Monitor_serviceDesc.Streams[8], c.cc, "/monitor.Monitor/HandlerUplink", opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -269,7 +377,7 @@ func (x *monitorHandlerUplinkClient) CloseAndRecv() (*google_protobuf1.Empty, er
 }
 
 func (c *monitorClient) HandlerDownlink(ctx context.Context, opts ...grpc.CallOption) (Monitor_HandlerDownlinkClient, error) {
-	stream, err := grpc.NewClientStream(ctx, &_Monitor_serviceDesc.Streams[6], c.cc, "/monitor.Monitor/HandlerDownlink", opts...)
+	stream, err := grpc.NewClientStream(ctx, &_Monitor_serviceDesc.Streams[9], c.cc, "/monitor.Monitor/HandlerDownlink", opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -302,20 +410,84 @@ func (x *monitorHandlerDownlinkClient) CloseAndRecv() (*google_protobuf1.Empty, 
 	return m, nil
 }
 
+func (c *monitorClient) NetworkServerStatus(ctx context.Context, opts ...grpc.CallOption) (Monitor_NetworkServerStatusClient, error) {
+	stream, err := grpc.NewClientStream(ctx, &_Monitor_serviceDesc.Streams[10], c.cc, "/monitor.Monitor/NetworkServerStatus", opts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &monitorNetworkServerStatusClient{stream}
+	return x, nil
+}
+
+type Monitor_NetworkServerStatusClient interface {
+	Send(*networkserver.Status) error
+	CloseAndRecv() (*google_protobuf1.Empty, error)
+	grpc.ClientStream
+}
+
+type monitorNetworkServerStatusClient struct {
+	grpc.ClientStream
+}
+
+func (x *monitorNetworkServerStatusClient) Send(m *networkserver.Status) error {
+	return x.ClientStream.SendMsg(m)
+}
+
+func (x *monitorNetworkServerStatusClient) CloseAndRecv() (*google_protobuf1.Empty, error) {
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	m := new(google_protobuf1.Empty)
+	if err := x.ClientStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
 // Server API for Monitor service
 
 type MonitorServer interface {
+	RouterStatus(Monitor_RouterStatusServer) error
 	GatewayStatus(Monitor_GatewayStatusServer) error
 	GatewayUplink(Monitor_GatewayUplinkServer) error
 	GatewayDownlink(Monitor_GatewayDownlinkServer) error
+	BrokerStatus(Monitor_BrokerStatusServer) error
 	BrokerUplink(Monitor_BrokerUplinkServer) error
 	BrokerDownlink(Monitor_BrokerDownlinkServer) error
+	HandlerStatus(Monitor_HandlerStatusServer) error
 	HandlerUplink(Monitor_HandlerUplinkServer) error
 	HandlerDownlink(Monitor_HandlerDownlinkServer) error
+	NetworkServerStatus(Monitor_NetworkServerStatusServer) error
 }
 
 func RegisterMonitorServer(s *grpc.Server, srv MonitorServer) {
 	s.RegisterService(&_Monitor_serviceDesc, srv)
+}
+
+func _Monitor_RouterStatus_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(MonitorServer).RouterStatus(&monitorRouterStatusServer{stream})
+}
+
+type Monitor_RouterStatusServer interface {
+	SendAndClose(*google_protobuf1.Empty) error
+	Recv() (*router.Status, error)
+	grpc.ServerStream
+}
+
+type monitorRouterStatusServer struct {
+	grpc.ServerStream
+}
+
+func (x *monitorRouterStatusServer) SendAndClose(m *google_protobuf1.Empty) error {
+	return x.ServerStream.SendMsg(m)
+}
+
+func (x *monitorRouterStatusServer) Recv() (*router.Status, error) {
+	m := new(router.Status)
+	if err := x.ServerStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
 }
 
 func _Monitor_GatewayStatus_Handler(srv interface{}, stream grpc.ServerStream) error {
@@ -396,6 +568,32 @@ func (x *monitorGatewayDownlinkServer) Recv() (*router.DownlinkMessage, error) {
 	return m, nil
 }
 
+func _Monitor_BrokerStatus_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(MonitorServer).BrokerStatus(&monitorBrokerStatusServer{stream})
+}
+
+type Monitor_BrokerStatusServer interface {
+	SendAndClose(*google_protobuf1.Empty) error
+	Recv() (*broker.Status, error)
+	grpc.ServerStream
+}
+
+type monitorBrokerStatusServer struct {
+	grpc.ServerStream
+}
+
+func (x *monitorBrokerStatusServer) SendAndClose(m *google_protobuf1.Empty) error {
+	return x.ServerStream.SendMsg(m)
+}
+
+func (x *monitorBrokerStatusServer) Recv() (*broker.Status, error) {
+	m := new(broker.Status)
+	if err := x.ServerStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
 func _Monitor_BrokerUplink_Handler(srv interface{}, stream grpc.ServerStream) error {
 	return srv.(MonitorServer).BrokerUplink(&monitorBrokerUplinkServer{stream})
 }
@@ -442,6 +640,32 @@ func (x *monitorBrokerDownlinkServer) SendAndClose(m *google_protobuf1.Empty) er
 
 func (x *monitorBrokerDownlinkServer) Recv() (*broker.DownlinkMessage, error) {
 	m := new(broker.DownlinkMessage)
+	if err := x.ServerStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func _Monitor_HandlerStatus_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(MonitorServer).HandlerStatus(&monitorHandlerStatusServer{stream})
+}
+
+type Monitor_HandlerStatusServer interface {
+	SendAndClose(*google_protobuf1.Empty) error
+	Recv() (*handler.Status, error)
+	grpc.ServerStream
+}
+
+type monitorHandlerStatusServer struct {
+	grpc.ServerStream
+}
+
+func (x *monitorHandlerStatusServer) SendAndClose(m *google_protobuf1.Empty) error {
+	return x.ServerStream.SendMsg(m)
+}
+
+func (x *monitorHandlerStatusServer) Recv() (*handler.Status, error) {
+	m := new(handler.Status)
 	if err := x.ServerStream.RecvMsg(m); err != nil {
 		return nil, err
 	}
@@ -500,11 +724,42 @@ func (x *monitorHandlerDownlinkServer) Recv() (*broker.DownlinkMessage, error) {
 	return m, nil
 }
 
+func _Monitor_NetworkServerStatus_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(MonitorServer).NetworkServerStatus(&monitorNetworkServerStatusServer{stream})
+}
+
+type Monitor_NetworkServerStatusServer interface {
+	SendAndClose(*google_protobuf1.Empty) error
+	Recv() (*networkserver.Status, error)
+	grpc.ServerStream
+}
+
+type monitorNetworkServerStatusServer struct {
+	grpc.ServerStream
+}
+
+func (x *monitorNetworkServerStatusServer) SendAndClose(m *google_protobuf1.Empty) error {
+	return x.ServerStream.SendMsg(m)
+}
+
+func (x *monitorNetworkServerStatusServer) Recv() (*networkserver.Status, error) {
+	m := new(networkserver.Status)
+	if err := x.ServerStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
 var _Monitor_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "monitor.Monitor",
 	HandlerType: (*MonitorServer)(nil),
 	Methods:     []grpc.MethodDesc{},
 	Streams: []grpc.StreamDesc{
+		{
+			StreamName:    "RouterStatus",
+			Handler:       _Monitor_RouterStatus_Handler,
+			ClientStreams: true,
+		},
 		{
 			StreamName:    "GatewayStatus",
 			Handler:       _Monitor_GatewayStatus_Handler,
@@ -521,6 +776,11 @@ var _Monitor_serviceDesc = grpc.ServiceDesc{
 			ClientStreams: true,
 		},
 		{
+			StreamName:    "BrokerStatus",
+			Handler:       _Monitor_BrokerStatus_Handler,
+			ClientStreams: true,
+		},
+		{
 			StreamName:    "BrokerUplink",
 			Handler:       _Monitor_BrokerUplink_Handler,
 			ClientStreams: true,
@@ -528,6 +788,11 @@ var _Monitor_serviceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "BrokerDownlink",
 			Handler:       _Monitor_BrokerDownlink_Handler,
+			ClientStreams: true,
+		},
+		{
+			StreamName:    "HandlerStatus",
+			Handler:       _Monitor_HandlerStatus_Handler,
 			ClientStreams: true,
 		},
 		{
@@ -540,6 +805,11 @@ var _Monitor_serviceDesc = grpc.ServiceDesc{
 			Handler:       _Monitor_HandlerDownlink_Handler,
 			ClientStreams: true,
 		},
+		{
+			StreamName:    "NetworkServerStatus",
+			Handler:       _Monitor_NetworkServerStatus_Handler,
+			ClientStreams: true,
+		},
 	},
 	Metadata: "github.com/TheThingsNetwork/ttn/api/monitor/monitor.proto",
 }
@@ -549,26 +819,31 @@ func init() {
 }
 
 var fileDescriptorMonitor = []byte{
-	// 328 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x92, 0x4f, 0x4b, 0xfb, 0x30,
-	0x18, 0xc7, 0x17, 0x7e, 0xf0, 0x1b, 0x04, 0xe7, 0xa0, 0xa0, 0xc2, 0xc4, 0x80, 0x37, 0x41, 0x48,
-	0x40, 0x4f, 0x7a, 0x92, 0x59, 0x51, 0xd0, 0x79, 0x71, 0x5e, 0xbc, 0xa5, 0x5b, 0xcc, 0xc2, 0xda,
-	0xa4, 0xa4, 0x4f, 0x29, 0xde, 0x7c, 0x09, 0xbe, 0x0c, 0x5f, 0x8a, 0x47, 0x8f, 0x1e, 0xb7, 0xfa,
-	0x12, 0x7c, 0x03, 0x62, 0x93, 0x88, 0x78, 0xd0, 0x89, 0x9e, 0xbe, 0x3c, 0x7f, 0xfa, 0x79, 0x3e,
-	0x2d, 0xc5, 0x7b, 0x52, 0xc1, 0xa4, 0x4c, 0xe8, 0xc8, 0x64, 0x6c, 0x38, 0x11, 0xc3, 0x89, 0xd2,
-	0xb2, 0x38, 0x17, 0x50, 0x19, 0x3b, 0x65, 0x00, 0x9a, 0xf1, 0x5c, 0xb1, 0xcc, 0x68, 0x05, 0xc6,
-	0x86, 0xa4, 0xb9, 0x35, 0x60, 0xa2, 0xb6, 0x2f, 0x7b, 0x1b, 0x61, 0x4f, 0x72, 0x10, 0x15, 0xbf,
-	0x09, 0xe9, 0xf6, 0x7a, 0xeb, 0x61, 0x6c, 0x4d, 0x09, 0xc2, 0xfa, 0xf8, 0x3c, 0x4c, 0xac, 0x99,
-	0x0a, 0xeb, 0x23, 0x0c, 0xa5, 0x31, 0x32, 0x15, 0xac, 0xa9, 0x92, 0xf2, 0x9a, 0x89, 0x2c, 0x07,
-	0x8f, 0xdd, 0x79, 0xf9, 0x87, 0xdb, 0x03, 0x67, 0x10, 0xed, 0xe3, 0xce, 0xb1, 0xbb, 0x79, 0x01,
-	0x1c, 0xca, 0x22, 0xea, 0xd2, 0xe0, 0xe0, 0x1a, 0xbd, 0x55, 0xea, 0x58, 0x34, 0xb0, 0xe8, 0xd1,
-	0x1b, 0x6b, 0x0b, 0x45, 0x07, 0xef, 0xcf, 0x5e, 0xe6, 0xa9, 0xd2, 0xd3, 0x68, 0x85, 0x7a, 0x43,
-	0x57, 0x0f, 0x44, 0x51, 0x70, 0x29, 0xbe, 0x20, 0xc4, 0xb8, 0xeb, 0x09, 0xb1, 0xa9, 0x74, 0xc3,
-	0x58, 0x0b, 0x8c, 0xd0, 0xf9, 0x9e, 0x72, 0x8a, 0x97, 0xfa, 0xcd, 0xcb, 0x7b, 0x8d, 0x4d, 0xea,
-	0xbf, 0x45, 0x2c, 0xc6, 0x65, 0x9e, 0xaa, 0x11, 0x07, 0x31, 0x5e, 0x54, 0xe9, 0x10, 0x2f, 0x3b,
-	0xd8, 0x07, 0xa3, 0x80, 0x5b, 0xd8, 0xe8, 0x0c, 0x77, 0x4e, 0xb8, 0x1e, 0xa7, 0x7f, 0xa3, 0x14,
-	0xe3, 0xae, 0xa7, 0xfd, 0xc2, 0xa9, 0x3f, 0x78, 0x9a, 0x93, 0xd6, 0x6c, 0x4e, 0xd0, 0x6d, 0x4d,
-	0xd0, 0x7d, 0x4d, 0xd0, 0x43, 0x4d, 0xd0, 0x63, 0x4d, 0xd0, 0xac, 0x26, 0xe8, 0xee, 0x99, 0xb4,
-	0xae, 0xb6, 0x7f, 0xf0, 0x47, 0x27, 0xff, 0x9b, 0x03, 0xbb, 0xaf, 0x01, 0x00, 0x00, 0xff, 0xff,
-	0xb2, 0xdf, 0x91, 0xcd, 0x07, 0x03, 0x00, 0x00,
+	// 402 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x94, 0xbd, 0x4e, 0xe3, 0x40,
+	0x10, 0xc7, 0xe3, 0xe2, 0x2e, 0xd2, 0x2a, 0x1f, 0x92, 0x4f, 0xb9, 0x93, 0x72, 0x62, 0x25, 0x3a,
+	0x10, 0xd2, 0x5a, 0x82, 0x26, 0xa4, 0x42, 0xc1, 0x7c, 0x48, 0x10, 0x0a, 0x12, 0x1a, 0x3a, 0x3b,
+	0x59, 0x6c, 0x2b, 0x8e, 0xd7, 0x5a, 0xaf, 0x89, 0xe8, 0x78, 0x04, 0x1e, 0x83, 0x47, 0xa1, 0xa4,
+	0xa4, 0x4c, 0x4c, 0xc9, 0x4b, 0x20, 0xbc, 0x33, 0x16, 0xa1, 0xc0, 0x41, 0x50, 0x8d, 0xc6, 0xb3,
+	0xff, 0xff, 0xce, 0xcf, 0x33, 0x36, 0xd9, 0xf5, 0x02, 0xe5, 0xa7, 0x2e, 0x1b, 0x89, 0xa9, 0x35,
+	0xf4, 0xf9, 0xd0, 0x0f, 0x22, 0x2f, 0x39, 0xe3, 0x6a, 0x26, 0xe4, 0xc4, 0x52, 0x2a, 0xb2, 0x9c,
+	0x38, 0xb0, 0xa6, 0x22, 0x0a, 0x94, 0x90, 0x18, 0x59, 0x2c, 0x85, 0x12, 0x66, 0x15, 0xd2, 0xf6,
+	0x1a, 0x9e, 0xf3, 0x1c, 0xc5, 0x67, 0xce, 0x0d, 0x46, 0x7d, 0xae, 0xfd, 0x1f, 0xcb, 0x52, 0xa4,
+	0x8a, 0x4b, 0x08, 0x1f, 0x8b, 0xae, 0x14, 0x13, 0x2e, 0x21, 0x40, 0xb1, 0x30, 0xf6, 0x9d, 0x68,
+	0x1c, 0x72, 0x89, 0x11, 0xca, 0x9b, 0x58, 0x8e, 0x74, 0xbf, 0x09, 0x97, 0xd7, 0x5c, 0x2e, 0x67,
+	0x78, 0x8d, 0x27, 0x84, 0x17, 0x72, 0x2b, 0xcf, 0xdc, 0xf4, 0xca, 0xe2, 0xd3, 0x58, 0x41, 0x83,
+	0xdb, 0x2f, 0xbf, 0x48, 0xb5, 0xaf, 0x59, 0xcc, 0x0e, 0xa9, 0x9d, 0xe7, 0xfd, 0x0d, 0x94, 0xa3,
+	0xd2, 0xc4, 0x6c, 0x30, 0x68, 0x57, 0xe7, 0xed, 0xbf, 0x4c, 0x3b, 0x31, 0x74, 0x62, 0x07, 0x6f,
+	0x4e, 0x1b, 0x86, 0xd9, 0x25, 0xf5, 0x23, 0xcd, 0x0d, 0xd2, 0x26, 0xc3, 0xf7, 0x50, 0xaa, 0xdd,
+	0x2b, 0xb4, 0x17, 0x71, 0x18, 0x44, 0x13, 0xb3, 0x85, 0xd7, 0xea, 0xbc, 0xcf, 0x93, 0xc4, 0xf1,
+	0xf8, 0x27, 0x0e, 0x36, 0x69, 0x82, 0x83, 0x2d, 0x66, 0x51, 0xee, 0xf1, 0x0f, 0x3d, 0xf0, 0x49,
+	0xb9, 0x4b, 0x87, 0xd4, 0x7a, 0xf9, 0x00, 0x0a, 0x7a, 0x98, 0x47, 0x29, 0xc1, 0x09, 0x2a, 0x01,
+	0x60, 0x1d, 0x95, 0x36, 0x1f, 0xa7, 0x71, 0x18, 0x8c, 0x1c, 0xc5, 0xc7, 0xab, 0xc2, 0xec, 0x93,
+	0x86, 0x36, 0x7b, 0xc7, 0x82, 0x76, 0x2b, 0xb3, 0x74, 0x49, 0xfd, 0x58, 0xaf, 0x4b, 0x31, 0x0f,
+	0x5c, 0x9f, 0x52, 0x9a, 0xd3, 0x42, 0xfb, 0x13, 0x38, 0x36, 0x69, 0x82, 0xdb, 0x77, 0x78, 0x0e,
+	0xc9, 0x1f, 0xf8, 0x2e, 0x07, 0xf9, 0x66, 0x03, 0x55, 0x8b, 0x2d, 0xef, 0x7b, 0x19, 0x5b, 0xaf,
+	0xff, 0xb4, 0xa0, 0x95, 0xf9, 0x82, 0x1a, 0xb7, 0x19, 0x35, 0xee, 0x33, 0x6a, 0x3c, 0x64, 0xd4,
+	0x78, 0xcc, 0xa8, 0x31, 0xcf, 0xa8, 0x71, 0xf7, 0x4c, 0x2b, 0x97, 0x5b, 0x5f, 0xf8, 0x27, 0xb8,
+	0xbf, 0xf3, 0x0b, 0x76, 0x5e, 0x03, 0x00, 0x00, 0xff, 0xff, 0x96, 0x7a, 0xdd, 0x8b, 0x49, 0x04,
+	0x00, 0x00,
 }

--- a/api/monitor/monitor.proto
+++ b/api/monitor/monitor.proto
@@ -6,6 +6,8 @@ syntax = "proto3";
 import "ttn/api/gateway/gateway.proto";
 import "ttn/api/router/router.proto";
 import "ttn/api/broker/broker.proto";
+import "ttn/api/handler/handler.proto";
+import "ttn/api/networkserver/networkserver.proto";
 
 import "google/protobuf/empty.proto";
 
@@ -14,13 +16,19 @@ package monitor;
 option go_package = "github.com/TheThingsNetwork/ttn/api/monitor";
 
 service Monitor {
+  rpc RouterStatus(stream router.Status) returns (google.protobuf.Empty);
+
   rpc GatewayStatus(stream gateway.Status) returns (google.protobuf.Empty);
   rpc GatewayUplink(stream router.UplinkMessage) returns (google.protobuf.Empty);
   rpc GatewayDownlink(stream router.DownlinkMessage) returns (google.protobuf.Empty);
 
+  rpc BrokerStatus(stream broker.Status) returns (google.protobuf.Empty);
   rpc BrokerUplink(stream broker.DeduplicatedUplinkMessage) returns (google.protobuf.Empty);
   rpc BrokerDownlink(stream broker.DownlinkMessage) returns (google.protobuf.Empty);
 
+  rpc HandlerStatus(stream handler.Status) returns (google.protobuf.Empty);
   rpc HandlerUplink(stream broker.DeduplicatedUplinkMessage) returns (google.protobuf.Empty);
   rpc HandlerDownlink(stream broker.DownlinkMessage) returns (google.protobuf.Empty);
+
+  rpc NetworkServerStatus(stream networkserver.Status) returns (google.protobuf.Empty);
 }

--- a/api/monitor/monitor_test.go
+++ b/api/monitor/monitor_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/TheThingsNetwork/ttn/api/broker"
 	"github.com/TheThingsNetwork/ttn/api/gateway"
 	"github.com/TheThingsNetwork/ttn/api/handler"
+	"github.com/TheThingsNetwork/ttn/api/networkserver"
 	"github.com/TheThingsNetwork/ttn/api/pool"
 	"github.com/TheThingsNetwork/ttn/api/router"
 	"github.com/htdvisser/grpc-testing/test"
@@ -75,6 +76,20 @@ func TestMonitor(t *testing.T) {
 
 	testLogger.Print(t)
 
+	rtr := cli.NewRouterStreams("test", "token")
+	time.Sleep(waitTime)
+	for i := 0; i < 20; i++ {
+		rtr.Send(&router.Status{})
+		time.Sleep(time.Millisecond)
+	}
+	time.Sleep(waitTime)
+	rtr.Close()
+	time.Sleep(waitTime)
+
+	a.So(server.metrics.routerStatuses, ShouldEqual, 20)
+
+	testLogger.Print(t)
+
 	brk := cli.NewBrokerStreams("test", "token")
 	time.Sleep(waitTime)
 	brk.Send(&broker.DeduplicatedUplinkMessage{})
@@ -87,6 +102,20 @@ func TestMonitor(t *testing.T) {
 
 	a.So(server.metrics.brokerUplinkMessages, ShouldEqual, 2)
 	a.So(server.metrics.brokerDownlinkMessages, ShouldEqual, 1)
+
+	testLogger.Print(t)
+
+	ns := cli.NewNetworkServerStreams("test", "token")
+	time.Sleep(waitTime)
+	for i := 0; i < 20; i++ {
+		ns.Send(&networkserver.Status{})
+		time.Sleep(time.Millisecond)
+	}
+	time.Sleep(waitTime)
+	ns.Close()
+	time.Sleep(waitTime)
+
+	a.So(server.metrics.routerStatuses, ShouldEqual, 20)
 
 	testLogger.Print(t)
 

--- a/api/monitor/monitor_test.go
+++ b/api/monitor/monitor_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/TheThingsNetwork/go-utils/log"
 	"github.com/TheThingsNetwork/ttn/api/broker"
 	"github.com/TheThingsNetwork/ttn/api/gateway"
+	"github.com/TheThingsNetwork/ttn/api/handler"
 	"github.com/TheThingsNetwork/ttn/api/pool"
 	"github.com/TheThingsNetwork/ttn/api/router"
 	"github.com/htdvisser/grpc-testing/test"
@@ -79,6 +80,7 @@ func TestMonitor(t *testing.T) {
 	brk.Send(&broker.DeduplicatedUplinkMessage{})
 	brk.Send(&broker.DeduplicatedDeviceActivationRequest{})
 	brk.Send(&broker.DownlinkMessage{})
+	brk.Send(&broker.Status{})
 	time.Sleep(waitTime)
 	brk.Close()
 	time.Sleep(waitTime)
@@ -93,6 +95,7 @@ func TestMonitor(t *testing.T) {
 	hdl.Send(&broker.DeduplicatedUplinkMessage{})
 	hdl.Send(&broker.DeduplicatedDeviceActivationRequest{})
 	hdl.Send(&broker.DownlinkMessage{})
+	hdl.Send(&handler.Status{})
 	time.Sleep(waitTime)
 	hdl.Close()
 	time.Sleep(waitTime)
@@ -114,5 +117,4 @@ func TestMonitor(t *testing.T) {
 	a.So(server.metrics.brokerUplinkMessages, ShouldEqual, 2)
 
 	testLogger.Print(t)
-
 }

--- a/api/monitor/reference_server.go
+++ b/api/monitor/reference_server.go
@@ -13,6 +13,8 @@ import (
 	"github.com/TheThingsNetwork/ttn/api/broker"
 	"github.com/TheThingsNetwork/ttn/api/fields"
 	"github.com/TheThingsNetwork/ttn/api/gateway"
+	"github.com/TheThingsNetwork/ttn/api/handler"
+	"github.com/TheThingsNetwork/ttn/api/networkserver"
 	"github.com/TheThingsNetwork/ttn/api/router"
 	"github.com/TheThingsNetwork/ttn/utils/errors"
 	"github.com/golang/protobuf/ptypes/empty"
@@ -28,11 +30,17 @@ func NewReferenceMonitorServer(bufferSize int) *ReferenceMonitorServer {
 		uplinkMessages:   make(chan *router.UplinkMessage, bufferSize),
 		downlinkMessages: make(chan *router.DownlinkMessage, bufferSize),
 
+		brokerStatuses:         make(chan *broker.Status, bufferSize),
 		brokerUplinkMessages:   make(chan *broker.DeduplicatedUplinkMessage, bufferSize),
 		brokerDownlinkMessages: make(chan *broker.DownlinkMessage, bufferSize),
 
+		handlerStatuses:         make(chan *handler.Status, bufferSize),
 		handlerUplinkMessages:   make(chan *broker.DeduplicatedUplinkMessage, bufferSize),
 		handlerDownlinkMessages: make(chan *broker.DownlinkMessage, bufferSize),
+
+		routerStatuses: make(chan *router.Status, bufferSize),
+
+		networkServerStatuses: make(chan *networkserver.Status, bufferSize),
 
 		metrics: new(metrics),
 	}
@@ -65,10 +73,14 @@ type metrics struct {
 	gatewayStatuses         uint64
 	uplinkMessages          uint64
 	downlinkMessages        uint64
+	brokerStatuses          uint64
 	brokerUplinkMessages    uint64
 	brokerDownlinkMessages  uint64
+	handlerStatuses         uint64
 	handlerUplinkMessages   uint64
 	handlerDownlinkMessages uint64
+	routerStatuses          uint64
+	networkServerStatuses   uint64
 }
 
 // ReferenceMonitorServer is a new reference monitor server
@@ -79,11 +91,17 @@ type ReferenceMonitorServer struct {
 	uplinkMessages   chan *router.UplinkMessage
 	downlinkMessages chan *router.DownlinkMessage
 
+	brokerStatuses         chan *broker.Status
 	brokerUplinkMessages   chan *broker.DeduplicatedUplinkMessage
 	brokerDownlinkMessages chan *broker.DownlinkMessage
 
+	handlerStatuses         chan *handler.Status
 	handlerUplinkMessages   chan *broker.DeduplicatedUplinkMessage
 	handlerDownlinkMessages chan *broker.DownlinkMessage
+
+	routerStatuses chan *router.Status
+
+	networkServerStatuses chan *networkserver.Status
 
 	metrics *metrics
 }
@@ -249,6 +267,47 @@ func (s *ReferenceMonitorServer) getAndAuthBroker(ctx context.Context) (string, 
 	return id, nil
 }
 
+// BrokerStatus RPC
+func (s *ReferenceMonitorServer) BrokerStatus(stream Monitor_BrokerStatusServer) (err error) {
+	brokerID, err := s.getAndAuthBroker(stream.Context())
+	if err != nil {
+		return errors.NewErrPermissionDenied(err.Error())
+	}
+	ctx := s.ctx.WithField("BrokerID", brokerID)
+	ctx.Info("BrokerStatus stream started")
+	defer func() {
+		if err != nil {
+			ctx.WithError(err).Info("BrokerStatus stream ended")
+		} else {
+			ctx.Info("BrokerStatus stream ended")
+		}
+	}()
+	var streamErr atomic.Value
+	go func() {
+		<-stream.Context().Done()
+		streamErr.Store(stream.Context().Err())
+	}()
+	for {
+		streamErr := streamErr.Load()
+		if streamErr != nil {
+			return streamErr.(error)
+		}
+		msg, err := stream.Recv()
+		if err == io.EOF {
+			return stream.SendAndClose(&empty.Empty{})
+		}
+		if err != nil {
+			return err
+		}
+		ctx.WithFields(fields.Get(msg)).Info("Received BrokerStatus")
+		select {
+		case s.brokerStatuses <- msg:
+		default:
+			ctx.Warn("Dropping Status")
+		}
+	}
+}
+
 // BrokerUplink RPC
 func (s *ReferenceMonitorServer) BrokerUplink(stream Monitor_BrokerUplinkServer) error {
 	brokerID, err := s.getAndAuthBroker(stream.Context())
@@ -355,6 +414,47 @@ func (s *ReferenceMonitorServer) getAndAuthHandler(ctx context.Context) (string,
 	return id, nil
 }
 
+// HandlerStatus RPC
+func (s *ReferenceMonitorServer) HandlerStatus(stream Monitor_HandlerStatusServer) (err error) {
+	handlerID, err := s.getAndAuthHandler(stream.Context())
+	if err != nil {
+		return errors.NewErrPermissionDenied(err.Error())
+	}
+	ctx := s.ctx.WithField("HandlerID", handlerID)
+	ctx.Info("HandlerStatus stream started")
+	defer func() {
+		if err != nil {
+			ctx.WithError(err).Info("HandlerStatus stream ended")
+		} else {
+			ctx.Info("HandlerStatus stream ended")
+		}
+	}()
+	var streamErr atomic.Value
+	go func() {
+		<-stream.Context().Done()
+		streamErr.Store(stream.Context().Err())
+	}()
+	for {
+		streamErr := streamErr.Load()
+		if streamErr != nil {
+			return streamErr.(error)
+		}
+		msg, err := stream.Recv()
+		if err == io.EOF {
+			return stream.SendAndClose(&empty.Empty{})
+		}
+		if err != nil {
+			return err
+		}
+		ctx.WithFields(fields.Get(msg)).Info("Received HandlerStatus")
+		select {
+		case s.handlerStatuses <- msg:
+		default:
+			ctx.Warn("Dropping Status")
+		}
+	}
+}
+
 // HandlerUplink RPC
 func (s *ReferenceMonitorServer) HandlerUplink(stream Monitor_HandlerUplinkServer) error {
 	handlerID, err := s.getAndAuthHandler(stream.Context())
@@ -443,6 +543,116 @@ func (s *ReferenceMonitorServer) HandlerDownlink(stream Monitor_HandlerDownlinkS
 		case s.handlerDownlinkMessages <- msg:
 		default:
 			ctx.Warn("Dropping DownlinkMessage")
+		}
+	}
+}
+
+func (s *ReferenceMonitorServer) getAndAuthRouter(ctx context.Context) (string, error) {
+	id, err := api.IDFromContext(ctx)
+	if err != nil {
+		return "", err
+	}
+	token, err := api.TokenFromContext(ctx)
+	if err != nil {
+		return "", err
+	}
+	// Actually validate token here, if failed: return nil, grpc.Errorf(codes.Unauthenticated, "Router Authentication Failed")
+	s.ctx.WithFields(log.Fields{"ID": id, "Token": token}).Info("Router Authenticated")
+	return id, nil
+}
+
+// RouterStatus RPC
+func (s *ReferenceMonitorServer) RouterStatus(stream Monitor_RouterStatusServer) (err error) {
+	routerID, err := s.getAndAuthRouter(stream.Context())
+	if err != nil {
+		return errors.NewErrPermissionDenied(err.Error())
+	}
+	ctx := s.ctx.WithField("RouterID", routerID)
+	ctx.Info("RouterStatus stream started")
+	defer func() {
+		if err != nil {
+			ctx.WithError(err).Info("RouterStatus stream ended")
+		} else {
+			ctx.Info("RouterStatus stream ended")
+		}
+	}()
+	var streamErr atomic.Value
+	go func() {
+		<-stream.Context().Done()
+		streamErr.Store(stream.Context().Err())
+	}()
+	for {
+		streamErr := streamErr.Load()
+		if streamErr != nil {
+			return streamErr.(error)
+		}
+		msg, err := stream.Recv()
+		if err == io.EOF {
+			return stream.SendAndClose(&empty.Empty{})
+		}
+		if err != nil {
+			return err
+		}
+		ctx.WithFields(fields.Get(msg)).Info("Received RouterStatus")
+		select {
+		case s.routerStatuses <- msg:
+		default:
+			ctx.Warn("Dropping Status")
+		}
+	}
+}
+
+func (s *ReferenceMonitorServer) getAndAuthNetworkServer(ctx context.Context) (string, error) {
+	id, err := api.IDFromContext(ctx)
+	if err != nil {
+		return "", err
+	}
+	token, err := api.TokenFromContext(ctx)
+	if err != nil {
+		return "", err
+	}
+	// Actually validate token here, if failed: return nil, grpc.Errorf(codes.Unauthenticated, "NetworkServer Authentication Failed")
+	s.ctx.WithFields(log.Fields{"ID": id, "Token": token}).Info("NetworkServer Authenticated")
+	return id, nil
+}
+
+// NetworkServerStatus RPC
+func (s *ReferenceMonitorServer) NetworkServerStatus(stream Monitor_NetworkServerStatusServer) (err error) {
+	networkServerID, err := s.getAndAuthNetworkServer(stream.Context())
+	if err != nil {
+		return errors.NewErrPermissionDenied(err.Error())
+	}
+	ctx := s.ctx.WithField("NetworkServerID", networkServerID)
+	ctx.Info("NetworkServerStatus stream started")
+	defer func() {
+		if err != nil {
+			ctx.WithError(err).Info("NetworkServerStatus stream ended")
+		} else {
+			ctx.Info("NetworkServerStatus stream ended")
+		}
+	}()
+	var streamErr atomic.Value
+	go func() {
+		<-stream.Context().Done()
+		streamErr.Store(stream.Context().Err())
+	}()
+	for {
+		streamErr := streamErr.Load()
+		if streamErr != nil {
+			return streamErr.(error)
+		}
+		msg, err := stream.Recv()
+		if err == io.EOF {
+			return stream.SendAndClose(&empty.Empty{})
+		}
+		if err != nil {
+			return err
+		}
+		ctx.WithFields(fields.Get(msg)).Info("Received NetworkServerStatus")
+		select {
+		case s.networkServerStatuses <- msg:
+		default:
+			ctx.Warn("Dropping Status")
 		}
 	}
 }

--- a/api/monitor/reference_server.go
+++ b/api/monitor/reference_server.go
@@ -54,14 +54,20 @@ func NewReferenceMonitorServer(bufferSize int) *ReferenceMonitorServer {
 					atomic.AddUint64(&s.metrics.uplinkMessages, 1)
 				case <-s.downlinkMessages:
 					atomic.AddUint64(&s.metrics.downlinkMessages, 1)
+				case <-s.routerStatuses:
+					atomic.AddUint64(&s.metrics.routerStatuses, 1)
 				case <-s.brokerUplinkMessages:
 					atomic.AddUint64(&s.metrics.brokerUplinkMessages, 1)
 				case <-s.brokerDownlinkMessages:
 					atomic.AddUint64(&s.metrics.brokerDownlinkMessages, 1)
+				case <-s.brokerStatuses:
+					atomic.AddUint64(&s.metrics.brokerStatuses, 1)
 				case <-s.handlerUplinkMessages:
 					atomic.AddUint64(&s.metrics.handlerUplinkMessages, 1)
 				case <-s.handlerDownlinkMessages:
 					atomic.AddUint64(&s.metrics.handlerDownlinkMessages, 1)
+				case <-s.handlerStatuses:
+					atomic.AddUint64(&s.metrics.handlerStatuses, 1)
 				}
 			}
 		}()


### PR DESCRIPTION
@htdvisser, when running `make -B protos`, content of all compiled protobuf files in repo changes, which should not happen, I suppose.

refs #572 