### PR TITLE
Publish multi-antenna Rx to MQTT as duplicate gateways

### DIFF
--- a/core/handler/convert_metadata.go
+++ b/core/handler/convert_metadata.go
@@ -49,7 +49,17 @@ func (h *handler) ConvertMetadata(ctx ttnlog.Interface, ttnUp *pb_broker.Dedupli
 			gatewayMetadata.Latitude = gps.Latitude
 		}
 
-		appUp.Metadata.Gateways = append(appUp.Metadata.Gateways, gatewayMetadata)
+		if antennas := in.GetAntennas(); len(antennas) > 0 {
+			for _, antenna := range antennas {
+				gatewayMetadata.Antenna = uint8(antenna.Antenna)
+				gatewayMetadata.Channel = antenna.Channel
+				gatewayMetadata.RSSI = antenna.Rssi
+				gatewayMetadata.SNR = antenna.Snr
+				appUp.Metadata.Gateways = append(appUp.Metadata.Gateways, gatewayMetadata)
+			}
+		} else {
+			appUp.Metadata.Gateways = append(appUp.Metadata.Gateways, gatewayMetadata)
+		}
 	}
 
 	// Inject Device Metadata

--- a/core/handler/convert_metadata_test.go
+++ b/core/handler/convert_metadata_test.go
@@ -41,12 +41,16 @@ func TestConvertMetadata(t *testing.T) {
 		},
 		&pb_gateway.RxMetadata{
 			GatewayId: gtwID,
+			Antennas: []*pb_gateway.RxMetadata_Antenna{
+				&pb_gateway.RxMetadata_Antenna{},
+				&pb_gateway.RxMetadata_Antenna{},
+			},
 		},
 	}
 
 	err = h.ConvertMetadata(h.Ctx, ttnUp, appUp, device)
 	a.So(err, ShouldBeNil)
-	a.So(appUp.Metadata.Gateways, ShouldHaveLength, 2)
+	a.So(appUp.Metadata.Gateways, ShouldHaveLength, 3)
 
 	ttnUp.ProtocolMetadata = &pb_protocol.RxMetadata{Protocol: &pb_protocol.RxMetadata_Lorawan{
 		Lorawan: &pb_lorawan.Metadata{

--- a/core/types/gateway_metadata.go
+++ b/core/types/gateway_metadata.go
@@ -9,6 +9,7 @@ type GatewayMetadata struct {
 	GtwTrusted bool     `json:"gtw_trusted,omitempty"`
 	Timestamp  uint32   `json:"timestamp,omitempty"`
 	Time       JSONTime `json:"time,omitempty"`
+	Antenna    uint8    `json:"antenna,omitempty"`
 	Channel    uint32   `json:"channel"`
 	RSSI       float32  `json:"rssi,omitempty"`
 	SNR        float32  `json:"snr,omitempty"`


### PR DESCRIPTION
This PR publishes multi-antenna Rx metadata to MQTT as duplicate gateways. 

I think this is a better solution than adding multiple `antennas` under the same gateway, as that wouldn't allow us to insert separate GPS locations for each antenna in the future. 