### PR TITLE
Types package randomizers

### DIFF
--- a/core/types/random.go
+++ b/core/types/random.go
@@ -29,7 +29,8 @@ func randRead(r Rand, b []byte) (n int, err error) {
 }
 
 // NewPopulatedDevAddr returns random DevAddr
-func NewPopulatedDevAddr(r Rand) (devAddr DevAddr) {
+func NewPopulatedDevAddr(r Rand) (devAddr *DevAddr) {
+	devAddr = &DevAddr{}
 	if _, err := randRead(r, devAddr[:]); err != nil {
 		panic(fmt.Errorf("types.NewPopulatedAppEUI: %s", err))
 	}
@@ -37,7 +38,8 @@ func NewPopulatedDevAddr(r Rand) (devAddr DevAddr) {
 }
 
 // NewPopulatedAppEUI returns random AppEUI
-func NewPopulatedAppEUI(r Rand) (appEUI AppEUI) {
+func NewPopulatedAppEUI(r Rand) (appEUI *AppEUI) {
+	appEUI = &AppEUI{}
 	if _, err := randRead(r, appEUI[:]); err != nil {
 		panic(fmt.Errorf("types.NewPopulatedAppEUI: %s", err))
 	}
@@ -45,7 +47,8 @@ func NewPopulatedAppEUI(r Rand) (appEUI AppEUI) {
 }
 
 // NewPopulatedDevEUI returns random DevEUI
-func NewPopulatedDevEUI(r Rand) (devEUI DevEUI) {
+func NewPopulatedDevEUI(r Rand) (devEUI *DevEUI) {
+	devEUI = &DevEUI{}
 	if _, err := randRead(r, devEUI[:]); err != nil {
 		panic(fmt.Errorf("types.NewPopulatedDevEUI: %s", err))
 	}

--- a/core/types/random.go
+++ b/core/types/random.go
@@ -1,0 +1,30 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package types
+
+import (
+	"fmt"
+	"math/rand"
+)
+
+func NewPopulatedDevAddr(r *rand.Rand) (devAddr DevAddr) {
+	if _, err := r.Read(devAddr[:]); err != nil {
+		panic(fmt.Errorf("types.NewPopulatedAppEUI: %s", err))
+	}
+	return
+}
+
+func NewPopulatedAppEUI(r *rand.Rand) (appEUI AppEUI) {
+	if _, err := r.Read(appEUI[:]); err != nil {
+		panic(fmt.Errorf("types.NewPopulatedAppEUI: %s", err))
+	}
+	return
+}
+
+func NewPopulatedDevEUI(r *rand.Rand) (devEUI DevEUI) {
+	if _, err := r.Read(devEUI[:]); err != nil {
+		panic(fmt.Errorf("types.NewPopulatedDevEUI: %s", err))
+	}
+	return
+}

--- a/core/types/random.go
+++ b/core/types/random.go
@@ -7,26 +7,46 @@ import (
 	"fmt"
 )
 
+// A Rand is a source of random int64 numbers
 type Rand interface {
-	Read(b []byte) (n int, err error)
+	Int63() int64
 }
 
+func randRead(r Rand, b []byte) (n int, err error) {
+	// Adapted from go stdlib https://goo.gl/i3vwnE
+	pos := 7
+	val := r.Int63()
+	for n := range b {
+		if pos == 0 {
+			val = r.Int63()
+			pos = 7
+		}
+		b[n] = byte(val)
+		val >>= 8
+		pos--
+	}
+	return
+}
+
+// NewPopulatedDevAddr returns random DevAddr
 func NewPopulatedDevAddr(r Rand) (devAddr DevAddr) {
-	if _, err := r.Read(devAddr[:]); err != nil {
+	if _, err := randRead(r, devAddr[:]); err != nil {
 		panic(fmt.Errorf("types.NewPopulatedAppEUI: %s", err))
 	}
 	return
 }
 
+// NewPopulatedAppEUI returns random AppEUI
 func NewPopulatedAppEUI(r Rand) (appEUI AppEUI) {
-	if _, err := r.Read(appEUI[:]); err != nil {
+	if _, err := randRead(r, appEUI[:]); err != nil {
 		panic(fmt.Errorf("types.NewPopulatedAppEUI: %s", err))
 	}
 	return
 }
 
+// NewPopulatedDevEUI returns random DevEUI
 func NewPopulatedDevEUI(r Rand) (devEUI DevEUI) {
-	if _, err := r.Read(devEUI[:]); err != nil {
+	if _, err := randRead(r, devEUI[:]); err != nil {
 		panic(fmt.Errorf("types.NewPopulatedDevEUI: %s", err))
 	}
 	return

--- a/core/types/random.go
+++ b/core/types/random.go
@@ -32,7 +32,7 @@ func randRead(r Rand, b []byte) (n int, err error) {
 func NewPopulatedDevAddr(r Rand) (devAddr *DevAddr) {
 	devAddr = &DevAddr{}
 	if _, err := randRead(r, devAddr[:]); err != nil {
-		panic(fmt.Errorf("types.NewPopulatedAppEUI: %s", err))
+		panic(fmt.Errorf("types.NewPopulatedDevAddr: %s", err))
 	}
 	return
 }

--- a/core/types/random.go
+++ b/core/types/random.go
@@ -5,24 +5,27 @@ package types
 
 import (
 	"fmt"
-	"math/rand"
 )
 
-func NewPopulatedDevAddr(r *rand.Rand) (devAddr DevAddr) {
+type Rand interface {
+	Read(b []byte) (n int, err error)
+}
+
+func NewPopulatedDevAddr(r Rand) (devAddr DevAddr) {
 	if _, err := r.Read(devAddr[:]); err != nil {
 		panic(fmt.Errorf("types.NewPopulatedAppEUI: %s", err))
 	}
 	return
 }
 
-func NewPopulatedAppEUI(r *rand.Rand) (appEUI AppEUI) {
+func NewPopulatedAppEUI(r Rand) (appEUI AppEUI) {
 	if _, err := r.Read(appEUI[:]); err != nil {
 		panic(fmt.Errorf("types.NewPopulatedAppEUI: %s", err))
 	}
 	return
 }
 
-func NewPopulatedDevEUI(r *rand.Rand) (devEUI DevEUI) {
+func NewPopulatedDevEUI(r Rand) (devEUI DevEUI) {
 	if _, err := r.Read(devEUI[:]); err != nil {
 		panic(fmt.Errorf("types.NewPopulatedDevEUI: %s", err))
 	}

--- a/core/types/random_test.go
+++ b/core/types/random_test.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/smartystreets/assertions"
 )
 
-var random = rand.New(rand.NewSource(time.Now().UnixNano()))
+var random Rand = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 func TestNewPopulatedDevAddr(t *testing.T) {
 	a := New(t)

--- a/core/types/random_test.go
+++ b/core/types/random_test.go
@@ -16,7 +16,7 @@ var random Rand = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 func TestNewPopulatedDevAddr(t *testing.T) {
 	a := New(t)
-	var devAddr DevAddr
+	var devAddr *DevAddr
 	a.So(func() {
 		devAddr = NewPopulatedDevAddr(random)
 	}, ShouldNotPanic)
@@ -26,7 +26,7 @@ func TestNewPopulatedDevAddr(t *testing.T) {
 
 func TestNewPopulatedAppEUI(t *testing.T) {
 	a := New(t)
-	var appEUI AppEUI
+	var appEUI *AppEUI
 	a.So(func() {
 		appEUI = NewPopulatedAppEUI(random)
 	}, ShouldNotPanic)
@@ -36,7 +36,7 @@ func TestNewPopulatedAppEUI(t *testing.T) {
 
 func TestNewPopulatedDevEUI(t *testing.T) {
 	a := New(t)
-	var devEUI DevEUI
+	var devEUI *DevEUI
 	a.So(func() {
 		devEUI = NewPopulatedDevEUI(random)
 	}, ShouldNotPanic)

--- a/core/types/random_test.go
+++ b/core/types/random_test.go
@@ -1,0 +1,45 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package types_test
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	. "github.com/TheThingsNetwork/ttn/core/types"
+	. "github.com/smartystreets/assertions"
+)
+
+var random = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+func TestNewPopulatedDevAddr(t *testing.T) {
+	a := New(t)
+	var devAddr DevAddr
+	a.So(func() {
+		devAddr = NewPopulatedDevAddr(random)
+	}, ShouldNotPanic)
+	a.So(devAddr.IsEmpty(), ShouldBeFalse)
+	a.So(devAddr.Size(), ShouldEqual, 4)
+}
+
+func TestNewPopulatedAppEUI(t *testing.T) {
+	a := New(t)
+	var appEUI AppEUI
+	a.So(func() {
+		appEUI = NewPopulatedAppEUI(random)
+	}, ShouldNotPanic)
+	a.So(appEUI.IsEmpty(), ShouldBeFalse)
+	a.So(appEUI.Size(), ShouldEqual, 8)
+}
+
+func TestNewPopulatedDevEUI(t *testing.T) {
+	a := New(t)
+	var devEUI DevEUI
+	a.So(func() {
+		devEUI = NewPopulatedDevEUI(random)
+	}, ShouldNotPanic)
+	a.So(devEUI.IsEmpty(), ShouldBeFalse)
+	a.So(devEUI.Size(), ShouldEqual, 8)
+}


### PR DESCRIPTION
Lack of these randomizers prevent using gogoproto `populate` option to auto-generate randomizers for types in NOC. This implementation does not add any additional dependencies to the `core/types` package, (test code is in separate `types_test` package) as was determined to be a requirement in previous discussion with @htdvisser.
`Read` function is not used, as interface generated by `gogoproto` does not provide it and `Int63()` is used under the hood anyway. Pointers are returned to match `gogoproto` expectations.