### PR TITLE
Feature 615 router gateway mapping in discovery

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ Hylke Visser <htdvisser@gmail.com>
 Jan Kramer <jan@jankramer.eu>
 Johan Stokking <johan@thethingsnetwork.org>
 Matthias Benkort <matthias.benkort@gmail.com>
+Romain Cambier <me@romaincambier.be>
 Roman Volosatovs <rvolosatovs@riseup.net>
 Romeo Van Snick <romeovs@gmail.com>
 Sylvain Prost <prostg.sylvain@gmail.com>

--- a/core/discovery/announcement/announcement.go
+++ b/core/discovery/announcement/announcement.go
@@ -61,6 +61,25 @@ func (m AppIDMetadata) MarshalText() ([]byte, error) {
 	return []byte(fmt.Sprintf("AppID %s", m.AppID)), nil
 }
 
+// GatewayIDMetadata is used to store a GatewayID
+type GatewayIDMetadata struct {
+	GatewayID string
+}
+
+// ToProto implements the Metadata interface
+func (m GatewayIDMetadata) ToProto() *pb.Metadata {
+	return &pb.Metadata{
+		Metadata: &pb.Metadata_GatewayId{
+			GatewayId: m.GatewayID,
+		},
+	}
+}
+
+// MarshalText implements the encoding.TextMarshaler interface
+func (m GatewayIDMetadata) MarshalText() ([]byte, error) {
+	return []byte(fmt.Sprintf("GatewayID %s", m.GatewayID)), nil
+}
+
 // PrefixMetadata is used to store a DevAddr prefix
 type PrefixMetadata struct {
 	Prefix types.DevAddrPrefix
@@ -89,8 +108,8 @@ func MetadataFromProto(proto *pb.Metadata) Metadata {
 		}
 		return AppEUIMetadata{*eui}
 	}
-	if id := proto.GetAppID(); id != "" {
-		return AppIDMetadata{id}
+	if appID := proto.GetAppID(); appID != "" {
+		return AppIDMetadata{appID}
 	}
 	if prefixBytes := proto.GetDevAddrPrefix(); prefixBytes != nil {
 		prefix := new(types.DevAddrPrefix)
@@ -98,6 +117,9 @@ func MetadataFromProto(proto *pb.Metadata) Metadata {
 			return nil
 		}
 		return PrefixMetadata{*prefix}
+	}
+	if gatewayID := proto.GetGatewayId(); gatewayID != "" {
+		return GatewayIDMetadata{gatewayID}
 	}
 	return nil
 }
@@ -114,6 +136,8 @@ func MetadataFromString(str string) Metadata {
 		return AppEUIMetadata{appEUI}
 	case "AppID":
 		return AppIDMetadata{value}
+	case "GatewayID":
+		return GatewayIDMetadata{value}
 	case "Prefix":
 		prefix := &types.DevAddrPrefix{
 			Length: 32,

--- a/core/discovery/announcement/announcement.go
+++ b/core/discovery/announcement/announcement.go
@@ -69,8 +69,8 @@ type GatewayIDMetadata struct {
 // ToProto implements the Metadata interface
 func (m GatewayIDMetadata) ToProto() *pb.Metadata {
 	return &pb.Metadata{
-		Metadata: &pb.Metadata_GatewayId{
-			GatewayId: m.GatewayID,
+		Metadata: &pb.Metadata_GatewayID{
+			GatewayID: m.GatewayID,
 		},
 	}
 }
@@ -118,7 +118,7 @@ func MetadataFromProto(proto *pb.Metadata) Metadata {
 		}
 		return PrefixMetadata{*prefix}
 	}
-	if gatewayID := proto.GetGatewayId(); gatewayID != "" {
+	if gatewayID := proto.GetGatewayID(); gatewayID != "" {
 		return GatewayIDMetadata{gatewayID}
 	}
 	return nil

--- a/core/discovery/announcement/cache.go
+++ b/core/discovery/announcement/cache.go
@@ -110,6 +110,18 @@ func (s *cachedAnnouncementStore) GetForAppID(appID string) (*Announcement, erro
 	return s.Get(serviceName, serviceID)
 }
 
+func (s *cachedAnnouncementStore) getForGatewayID(gatewayID string) (string, string, error) {
+	return s.backingStore.getForGatewayID(gatewayID)
+}
+
+func (s *cachedAnnouncementStore) GetForGatewayID(gatewayID string) (*Announcement, error) {
+	serviceName, serviceID, err := s.getForGatewayID(gatewayID)
+	if err != nil {
+		return nil, err
+	}
+	return s.Get(serviceName, serviceID)
+}
+
 func (s *cachedAnnouncementStore) getForAppEUI(appEUI types.AppEUI) (string, string, error) {
 	return s.backingStore.getForAppEUI(appEUI)
 }

--- a/core/discovery/announcement/store.go
+++ b/core/discovery/announcement/store.go
@@ -23,6 +23,8 @@ type Store interface {
 	GetMetadata(serviceName, serviceID string) ([]Metadata, error)
 	getForAppID(appID string) (serviceName, serviceID string, err error)
 	GetForAppID(appID string) (*Announcement, error)
+	getForGatewayID(gatewayID string) (serviceName, serviceID string, err error)
+	GetForGatewayID(gatewayID string) (*Announcement, error)
 	getForAppEUI(appEUI types.AppEUI) (serviceName, serviceID string, err error)
 	GetForAppEUI(appEUI types.AppEUI) (*Announcement, error)
 	Set(new *Announcement) error
@@ -37,6 +39,7 @@ const redisAnnouncementPrefix = "announcement"
 const redisMetadataPrefix = "metadata"
 const redisAppIDPrefix = "app_id"
 const redisAppEUIPrefix = "app_eui"
+const redisGatewayIDPrefix = "gateway_id"
 
 // NewRedisAnnouncementStore creates a new Redis-based Announcement store
 func NewRedisAnnouncementStore(client *redis.Client, prefix string) Store {
@@ -49,10 +52,11 @@ func NewRedisAnnouncementStore(client *redis.Client, prefix string) Store {
 		store.AddMigration(v, f)
 	}
 	return &RedisAnnouncementStore{
-		store:    store,
-		metadata: storage.NewRedisSetStore(client, prefix+":"+redisMetadataPrefix),
-		byAppID:  storage.NewRedisKVStore(client, prefix+":"+redisAppIDPrefix),
-		byAppEUI: storage.NewRedisKVStore(client, prefix+":"+redisAppEUIPrefix),
+		store:       store,
+		metadata:    storage.NewRedisSetStore(client, prefix+":"+redisMetadataPrefix),
+		byAppID:     storage.NewRedisKVStore(client, prefix+":"+redisAppIDPrefix),
+		byAppEUI:    storage.NewRedisKVStore(client, prefix+":"+redisAppEUIPrefix),
+		byGatewayID: storage.NewRedisKVStore(client, prefix+":"+redisGatewayIDPrefix),
 	}
 }
 
@@ -61,10 +65,11 @@ func NewRedisAnnouncementStore(client *redis.Client, prefix string) Store {
 // - Metadata is stored in a Set
 // - AppIDs and AppEUIs are indexed with key/value pairs
 type RedisAnnouncementStore struct {
-	store    *storage.RedisMapStore
-	metadata *storage.RedisSetStore
-	byAppID  *storage.RedisKVStore
-	byAppEUI *storage.RedisKVStore
+	store       *storage.RedisMapStore
+	metadata    *storage.RedisSetStore
+	byAppID     *storage.RedisKVStore
+	byAppEUI    *storage.RedisKVStore
+	byGatewayID *storage.RedisKVStore
 }
 
 // List all Announcements
@@ -137,6 +142,24 @@ func (s *RedisAnnouncementStore) GetMetadata(serviceName, serviceID string) ([]M
 		}
 	}
 	return out, nil
+}
+
+func (s *RedisAnnouncementStore) getForGatewayID(gatewayID string) (string, string, error) {
+	key, err := s.byGatewayID.Get(gatewayID)
+	if err != nil {
+		return "", "", err
+	}
+	service := strings.Split(key, ":")
+	return service[0], service[1], nil
+}
+
+// GetForGatewayID returns the last Announcement that contains metadata for the given GatewayID
+func (s *RedisAnnouncementStore) GetForGatewayID(gatewayID string) (*Announcement, error) {
+	serviceName, serviceID, err := s.getForGatewayID(gatewayID)
+	if err != nil {
+		return nil, err
+	}
+	return s.Get(serviceName, serviceID)
 }
 
 func (s *RedisAnnouncementStore) getForAppID(appID string) (string, string, error) {
@@ -221,6 +244,23 @@ func (s *RedisAnnouncementStore) AddMetadata(serviceName, serviceID string, meta
 					return err
 				}
 			}
+		case GatewayIDMetadata:
+			existing, err := s.byGatewayID.Get(meta.GatewayID)
+			switch {
+			case errors.GetErrType(err) == errors.NotFound:
+				if err := s.byGatewayID.Create(meta.GatewayID, key); err != nil {
+					return err
+				}
+			case err != nil:
+				return err
+			case existing == key:
+				continue
+			default:
+				go s.metadata.Remove(existing, string(txt))
+				if err := s.byGatewayID.Update(meta.GatewayID, key); err != nil {
+					return err
+				}
+			}
 		case AppEUIMetadata:
 			existing, err := s.byAppEUI.Get(meta.AppEUI.String())
 			switch {
@@ -257,6 +297,8 @@ func (s *RedisAnnouncementStore) RemoveMetadata(serviceName, serviceID string, m
 		switch meta := meta.(type) {
 		case AppIDMetadata:
 			s.byAppID.Delete(meta.AppID)
+		case GatewayIDMetadata:
+			s.byGatewayID.Delete(meta.GatewayID)
 		case AppEUIMetadata:
 			s.byAppEUI.Delete(meta.AppEUI.String())
 		}

--- a/core/discovery/discovery.go
+++ b/core/discovery/discovery.go
@@ -131,6 +131,14 @@ func (d *discovery) GetByAppID(appID string) (*pb.Announcement, error) {
 	return service.ToProto(), nil
 }
 
+func (d *discovery) GetByGatewayID(gatewayID string) (*pb.Announcement, error) {
+	service, err := d.services.GetForGatewayID(gatewayID)
+	if err != nil {
+		return nil, err
+	}
+	return service.ToProto(), nil
+}
+
 func (d *discovery) GetByAppEUI(appEUI types.AppEUI) (*pb.Announcement, error) {
 	service, err := d.services.GetForAppEUI(appEUI)
 	if err != nil {

--- a/core/discovery/server.go
+++ b/core/discovery/server.go
@@ -32,7 +32,7 @@ func (d *discoveryServer) checkMetadataEditRights(ctx context.Context, in *pb.Me
 	appEUI := in.Metadata.GetAppEUI()
 	appID := in.Metadata.GetAppID()
 	prefix := in.Metadata.GetDevAddrPrefix()
-	gatewayID := in.Metadata.GetGatewayId()
+	gatewayID := in.Metadata.GetGatewayID()
 
 	if appEUI == nil && appID == "" && prefix == nil && gatewayID == "" {
 		return errPermissionDeniedf("Unknown Metadata type")
@@ -185,7 +185,7 @@ func (d *discoveryServer) GetByAppID(ctx context.Context, req *pb.GetByAppIDRequ
 }
 
 func (d *discoveryServer) GetByGatewayID(ctx context.Context, req *pb.GetByGatewayIDRequest) (*pb.Announcement, error) {
-	service, err := d.discovery.GetByGatewayID(req.GatewayId)
+	service, err := d.discovery.GetByGatewayID(req.GatewayID)
 	if err != nil {
 		return nil, err
 	}

--- a/core/discovery/server.go
+++ b/core/discovery/server.go
@@ -32,8 +32,9 @@ func (d *discoveryServer) checkMetadataEditRights(ctx context.Context, in *pb.Me
 	appEUI := in.Metadata.GetAppEUI()
 	appID := in.Metadata.GetAppID()
 	prefix := in.Metadata.GetDevAddrPrefix()
+	gatewayID := in.Metadata.GetGatewayId()
 
-	if appEUI == nil && appID == "" && prefix == nil {
+	if appEUI == nil && appID == "" && prefix == nil && gatewayID == "" {
 		return errPermissionDeniedf("Unknown Metadata type")
 	}
 
@@ -45,6 +46,11 @@ func (d *discoveryServer) checkMetadataEditRights(ctx context.Context, in *pb.Me
 	// DevAddrPrefix can only be added to Brokers
 	if prefix != nil && in.ServiceName != "broker" {
 		return errPermissionDeniedf("Announcement service type should be \"broker\"")
+	}
+
+	// GatewayID can only be added to Routers
+	if gatewayID != "" && in.ServiceName != "router" {
+		return errPermissionDeniedf("Announcement service type should be \"router\"")
 	}
 
 	// DevAddrPrefix and AppEUI are network level changes
@@ -79,6 +85,13 @@ func (d *discoveryServer) checkMetadataEditRights(ctx context.Context, in *pb.Me
 	if appID != "" {
 		if !claims.AppRight(appID, rights.AppDelete) {
 			return errPermissionDeniedf(`No "%s" rights to Application "%s"`, rights.AppDelete, appID)
+		}
+	}
+
+	// Check claims for GatewayID
+	if gatewayID != "" {
+		if !claims.GatewayRight(gatewayID, rights.GatewayDelete) || (claims.Type == "gateway" && claims.Subject == gatewayID) {
+			return errPermissionDeniedf(`No "%s" rights to Gateway "%s"`, rights.GatewayDelete, gatewayID)
 		}
 	}
 	return nil
@@ -165,6 +178,14 @@ func (d *discoveryServer) Get(ctx context.Context, req *pb.GetRequest) (*pb.Anno
 
 func (d *discoveryServer) GetByAppID(ctx context.Context, req *pb.GetByAppIDRequest) (*pb.Announcement, error) {
 	service, err := d.discovery.GetByAppID(req.AppID)
+	if err != nil {
+		return nil, err
+	}
+	return service, nil
+}
+
+func (d *discoveryServer) GetByGatewayID(ctx context.Context, req *pb.GetByGatewayIDRequest) (*pb.Announcement, error) {
+	service, err := d.discovery.GetByGatewayID(req.GatewayId)
 	if err != nil {
 		return nil, err
 	}

--- a/core/discovery/server_test.go
+++ b/core/discovery/server_test.go
@@ -81,6 +81,10 @@ func (d *mockDiscoveryServer) GetByAppID(ctx context.Context, req *pb.GetByAppID
 	<-time.After(5 * time.Millisecond)
 	return &pb.Announcement{}, nil
 }
+func (d *mockDiscoveryServer) GetByGatewayID(ctx context.Context, req *pb.GetByGatewayIDRequest) (*pb.Announcement, error) {
+	<-time.After(5 * time.Millisecond)
+	return &pb.Announcement{}, nil
+}
 func (d *mockDiscoveryServer) GetByAppEUI(ctx context.Context, req *pb.GetByAppEUIRequest) (*pb.Announcement, error) {
 	<-time.After(5 * time.Millisecond)
 	return &pb.Announcement{}, nil

--- a/core/router/downlink.go
+++ b/core/router/downlink.go
@@ -31,6 +31,7 @@ func (r *router) SubscribeDownlink(gatewayID string, subscriptionID string) (<-c
 
 	gateway := r.getGateway(gatewayID)
 	if fromSchedule := gateway.Schedule.Subscribe(subscriptionID); fromSchedule != nil {
+		r.Discovery.AddGatewayID(gatewayID, gateway.Token())
 		toGateway := make(chan *pb.DownlinkMessage)
 		go func() {
 			ctx.Debug("Activate downlink")
@@ -52,7 +53,9 @@ func (r *router) SubscribeDownlink(gatewayID string, subscriptionID string) (<-c
 }
 
 func (r *router) UnsubscribeDownlink(gatewayID string, subscriptionID string) error {
-	r.getGateway(gatewayID).Schedule.Stop(subscriptionID)
+	gateway := r.getGateway(gatewayID)
+	r.Discovery.RemoveGatewayID(gatewayID, gateway.Token())
+	gateway.Schedule.Stop(subscriptionID)
 	return nil
 }
 

--- a/core/router/downlink_test.go
+++ b/core/router/downlink_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	pb_broker "github.com/TheThingsNetwork/api/broker"
+	"github.com/TheThingsNetwork/api/discovery"
 	pb_gateway "github.com/TheThingsNetwork/api/gateway"
 	"github.com/TheThingsNetwork/api/monitor/monitorclient"
 	pb_protocol "github.com/TheThingsNetwork/api/protocol"
@@ -17,6 +18,7 @@ import (
 	"github.com/TheThingsNetwork/ttn/core/component"
 	"github.com/TheThingsNetwork/ttn/core/router/gateway"
 	. "github.com/TheThingsNetwork/ttn/utils/testing"
+	"github.com/golang/mock/gomock"
 	. "github.com/smartystreets/assertions"
 	"golang.org/x/net/context"
 )
@@ -69,19 +71,25 @@ func TestHandleDownlink(t *testing.T) {
 
 func TestSubscribeUnsubscribeDownlink(t *testing.T) {
 	a := New(t)
-
+	ctrl := gomock.NewController(t)
+	discoveryClient := discovery.NewMockClient(ctrl)
 	logger := GetLogger(t, "TestSubscribeUnsubscribeDownlink")
 	r := &router{
 		Component: &component.Component{
-			Context: context.Background(),
-			Ctx:     logger,
-			Monitor: monitorclient.NewMonitorClient(),
+			Context:   context.Background(),
+			Ctx:       logger,
+			Monitor:   monitorclient.NewMonitorClient(),
+			Discovery: discoveryClient,
 		},
 		gateways: map[string]*gateway.Gateway{},
 	}
 	r.InitStatus()
 
 	gtwID := "eui-0102030405060708"
+
+	discoveryClient.EXPECT().AddGatewayID(gtwID, "").Return(nil)
+	discoveryClient.EXPECT().RemoveGatewayID(gtwID, "").Return(nil)
+
 	gateway.Deadline = 1 * time.Millisecond
 	gtw := r.getGateway(gtwID)
 	gtw.Schedule.Sync(0)

--- a/core/router/downlink_test.go
+++ b/core/router/downlink_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	pb_broker "github.com/TheThingsNetwork/api/broker"
-	"github.com/TheThingsNetwork/api/discovery"
+	"github.com/TheThingsNetwork/api/discovery/discoveryclient"
 	pb_gateway "github.com/TheThingsNetwork/api/gateway"
 	"github.com/TheThingsNetwork/api/monitor/monitorclient"
 	pb_protocol "github.com/TheThingsNetwork/api/protocol"
@@ -72,7 +72,7 @@ func TestHandleDownlink(t *testing.T) {
 func TestSubscribeUnsubscribeDownlink(t *testing.T) {
 	a := New(t)
 	ctrl := gomock.NewController(t)
-	discoveryClient := discovery.NewMockClient(ctrl)
+	discoveryClient := discoveryclient.NewMockClient(ctrl)
 	logger := GetLogger(t, "TestSubscribeUnsubscribeDownlink")
 	r := &router{
 		Component: &component.Component{

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -9,10 +9,10 @@
 			"revisionTime": "2017-04-10T19:29:09Z"
 		},
 		{
-			"checksumSHA1": "+/an8GeFMUwMQ7Ik3RmXOpyf5lk=",
+			"checksumSHA1": "XAMbw4O4bcDKEEQiC3ZRldHY/dg=",
 			"path": "github.com/TheThingsNetwork/api",
-			"revision": "560be39d3424ca851779df1a8c9329976b74a540",
-			"revisionTime": "2017-07-21T07:02:16Z"
+			"revision": "56d230882a3b4c4ac85ad882ec902c790f1c1a2a",
+			"revisionTime": "2017-07-26T15:04:12Z"
 		},
 		{
 			"checksumSHA1": "Rw+hj+XOq4Q56t5lLnMA5Bgjo18=",
@@ -27,16 +27,16 @@
 			"revisionTime": "2017-07-21T07:02:16Z"
 		},
 		{
-			"checksumSHA1": "6Ggao/KY9AIc8LdEviIeAwvrq6E=",
+			"checksumSHA1": "Aly2VuBqd8enG/9cUCqWKP219c8=",
 			"path": "github.com/TheThingsNetwork/api/discovery",
-			"revision": "560be39d3424ca851779df1a8c9329976b74a540",
-			"revisionTime": "2017-07-21T07:02:16Z"
+			"revision": "56d230882a3b4c4ac85ad882ec902c790f1c1a2a",
+			"revisionTime": "2017-07-26T15:04:12Z"
 		},
 		{
-			"checksumSHA1": "Bl0OHc+NIiYUfnt3kUm6WD1Iim8=",
+			"checksumSHA1": "zXx+EmyutkG/vJhaG6lzD1obrNM=",
 			"path": "github.com/TheThingsNetwork/api/discovery/discoveryclient",
-			"revision": "560be39d3424ca851779df1a8c9329976b74a540",
-			"revisionTime": "2017-07-21T07:02:16Z"
+			"revision": "56d230882a3b4c4ac85ad882ec902c790f1c1a2a",
+			"revisionTime": "2017-07-26T15:04:12Z"
 		},
 		{
 			"checksumSHA1": "eNHiocytCDERZCIwwXhjfH0Uyqc=",


### PR DESCRIPTION
This one adds the ability for the discovery service to store router <-> gateway mapping.

The router updates this mapping (metadata) in the discovery service on gateway downlink subscribe/unsubscribe

This is mainly required for class C usage.