### PR TITLE
Added clients commands to ttnctl

### DIFF
--- a/ttnctl/cmd/clients.go
+++ b/ttnctl/cmd/clients.go
@@ -1,0 +1,24 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package cmd
+
+import (
+	"github.com/TheThingsNetwork/ttn/ttnctl/util"
+	"github.com/spf13/cobra"
+)
+
+var clientsCmd = &cobra.Command{
+	Use:     "clients",
+	Aliases: []string{"client"},
+	Short:   "Manage OAuth clients",
+	Long:    `ttnctl clients can be used to manage OAuth clients.`,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		RootCmd.PersistentPreRun(cmd, args)
+		util.GetAccount(ctx)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(clientsCmd)
+}

--- a/ttnctl/cmd/clients.go
+++ b/ttnctl/cmd/clients.go
@@ -9,6 +9,7 @@ import (
 )
 
 var clientsCmd = &cobra.Command{
+	Hidden:  true,
 	Use:     "clients",
 	Aliases: []string{"client"},
 	Short:   "Manage OAuth clients",

--- a/ttnctl/cmd/clients_delete.go
+++ b/ttnctl/cmd/clients_delete.go
@@ -12,8 +12,8 @@ var clientDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "Delete an OAuth client",
 	Long:  "ttnctl clients delete removes an OAuth client.",
-	Example: `$ ttnctl clients delete oauthclient1
-  INFO OAuth client removed successfully OAuthClientName=oauthclient1
+	Example: `$ ttnctl clients delete my-gateway-client
+  INFO OAuth client deleted successfully OAuthClientName=my-gateway-client
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		assertArgsLength(cmd, args, 1, 1)
@@ -27,7 +27,7 @@ var clientDeleteCmd = &cobra.Command{
 			ctx.WithError(err).Fatal("Failed to delete OAuth client")
 		}
 
-		ctx.Info("OAuth client removed successfully")
+		ctx.Info("OAuth client deleted successfully")
 	},
 }
 

--- a/ttnctl/cmd/clients_delete.go
+++ b/ttnctl/cmd/clients_delete.go
@@ -1,0 +1,36 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package cmd
+
+import (
+	"github.com/TheThingsNetwork/ttn/ttnctl/util"
+	"github.com/spf13/cobra"
+)
+
+var clientDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete an OAuth client",
+	Long:  "ttnctl clients delete removes an OAuth client.",
+	Example: `$ ttnctl clients delete oauthclient1
+  INFO OAuth client removed successfully OAuthClientName=oauthclient1
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		assertArgsLength(cmd, args, 1, 1)
+
+		ctx = ctx.WithField("OAuthClientName", args[0])
+
+		account := util.GetAccount(ctx)
+
+		err := account.RemoveOAuthClient(args[0])
+		if err != nil {
+			ctx.WithError(err).Fatal("Failed to delete OAuth client")
+		}
+
+		ctx.Info("OAuth client removed successfully")
+	},
+}
+
+func init() {
+	clientsCmd.AddCommand(clientDeleteCmd)
+}

--- a/ttnctl/cmd/clients_delete.go
+++ b/ttnctl/cmd/clients_delete.go
@@ -9,7 +9,7 @@ import (
 )
 
 var clientDeleteCmd = &cobra.Command{
-	Use:   "delete",
+	Use:   "delete [OAuth client name]",
 	Short: "Delete an OAuth client",
 	Long:  "ttnctl clients delete removes an OAuth client.",
 	Example: `$ ttnctl clients delete my-gateway-client

--- a/ttnctl/cmd/clients_edit.go
+++ b/ttnctl/cmd/clients_edit.go
@@ -52,7 +52,8 @@ var clientEditCmd = &cobra.Command{
 		}
 
 		if !edited {
-			ctx.Fatal("No property to edit")
+			ctx.Info("No property to edit")
+			return
 		}
 
 		err = account.EditOAuthClient(name, client)

--- a/ttnctl/cmd/clients_edit.go
+++ b/ttnctl/cmd/clients_edit.go
@@ -6,17 +6,16 @@ package cmd
 import (
 	"github.com/TheThingsNetwork/ttn/ttnctl/util"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 var clientEditCmd = &cobra.Command{
 	Use:   "edit [Name]",
-	Short: "Edit the general information of an existing client",
-	Long:  "ttnctl clients edit can be used to edit the general information of an existing OAuth client",
-	Example: `$ ttnctl clients edit oauthClient1 --name oauthclient-new-name --description "OAuth client used by the console"
-  INFO Retrieving OAuth client...               OAuthClientID=oauthClient1
-  INFO Retrieved OAuth client                   OAuthClientID=oauthClient1
-  INFO OAuth client updated                     OAuthClientID=oauthclient-new-name
+	Short: "Edit the OAuth client",
+	Long:  "ttnctl clients edit can be used to edit the information of an OAuth client.",
+	Example: `$ ttnctl clients edit my-gateway-client --description "OAuth client for my personal gateway client"
+  INFO Retrieving OAuth client...               OAuthClientName=my-gateway-client
+  INFO Retrieved OAuth client                   OAuthClientName=my-gateway-client
+  INFO OAuth client edited                      OAuthClientName=my-gateway-client
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		assertArgsLength(cmd, args, 1, 1)

--- a/ttnctl/cmd/clients_edit.go
+++ b/ttnctl/cmd/clients_edit.go
@@ -11,7 +11,7 @@ import (
 var clientEditCmd = &cobra.Command{
 	Use:   "edit [Name]",
 	Short: "Edit the OAuth client",
-	Long:  "ttnctl clients edit can be used to edit the information of an OAuth client.",
+	Long:  "ttnctl clients edit can be used to edit the OAuth client.",
 	Example: `$ ttnctl clients edit my-gateway-client --description "OAuth client for my personal gateway client"
   INFO Retrieving OAuth client...               OAuthClientName=my-gateway-client
   INFO Retrieved OAuth client                   OAuthClientName=my-gateway-client

--- a/ttnctl/cmd/clients_edit.go
+++ b/ttnctl/cmd/clients_edit.go
@@ -1,0 +1,80 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package cmd
+
+import (
+	"github.com/TheThingsNetwork/ttn/ttnctl/util"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var clientEditCmd = &cobra.Command{
+	Use:   "edit [Name]",
+	Short: "Edit the general information of an existing client",
+	Long:  "ttnctl clients edit can be used to edit the general information of an existing OAuth client",
+	Example: `$ ttnctl clients edit oauthClient1 --name oauthclient-new-name --description "OAuth client used by the console"
+  INFO Retrieving OAuth client...               OAuthClientID=oauthClient1
+  INFO Retrieved OAuth client                   OAuthClientID=oauthClient1
+  INFO OAuth client updated                     OAuthClientID=oauthclient-new-name
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		assertArgsLength(cmd, args, 1, 1)
+
+		var name = args[0]
+
+		account := util.GetAccount(ctx)
+
+		clientCtx := ctx.WithField("OAuthClientID", name)
+
+		// Verifying that there is information to edit
+		var flagsSet bool
+		cmd.Flags().Visit(func(*pflag.Flag) { flagsSet = true })
+		if !flagsSet {
+			clientCtx.Fatal("No information to edit")
+		}
+
+		clientCtx.Info("Retrieving OAuth client...")
+		client, err := account.FindOAuthClient(name)
+		if err != nil {
+			clientCtx.WithError(err).Fatal("Could not find OAuth client")
+		}
+		if client == nil {
+			clientCtx.Fatal("No OAuth client returned by the server")
+		}
+		clientCtx.Info("Retrieved OAuth client")
+
+		if newName, err := cmd.Flags().GetString("name"); err != nil {
+			clientCtx.WithError(err).Fatal("Couldn't parse new name")
+		} else if newName != "" {
+			client.Name = newName
+			clientCtx = ctx.WithField("OAuthClientID", newName)
+		}
+
+		if newDescription, err := cmd.Flags().GetString("description"); err != nil {
+			clientCtx.WithError(err).Fatal("Couldn't parse description")
+		} else if newDescription != "" {
+			client.Description = newDescription
+		}
+
+		if newURI, err := cmd.Flags().GetString("uri"); err != nil {
+			clientCtx.WithError(err).Fatal("Couldn't parse URI")
+		} else if newURI != "" {
+			client.URI = newURI
+		}
+
+		err = account.EditOAuthClient(name, client)
+		if err != nil {
+			ctx.WithField("OAuthClientID", name).WithError(err).Fatal("Couldn't update OAuth client")
+		}
+
+		clientCtx.Info("OAuth client information updated")
+	},
+}
+
+func init() {
+	clientsCmd.AddCommand(clientEditCmd)
+	clientEditCmd.Flags().String("name", "", "Edit the name of the OAuth client")
+	clientEditCmd.Flags().String("description", "", "Edit the description of the OAuth client")
+	clientEditCmd.Flags().String("uri", "", "Edit the URI of the OAuth client")
+}

--- a/ttnctl/cmd/clients_edit.go
+++ b/ttnctl/cmd/clients_edit.go
@@ -38,14 +38,14 @@ var clientEditCmd = &cobra.Command{
 
 		var edited bool
 		if newDescription, err := cmd.Flags().GetString("description"); err != nil {
-			ctx.WithError(err).Fatal("Nothing to parse")
+			ctx.WithError(err).Fatal("Flag error")
 		} else if newDescription != "" {
 			edited = true
 			client.Description = newDescription
 		}
 
 		if newURI, err := cmd.Flags().GetString("uri"); err != nil {
-			ctx.WithError(err).Fatal("Nothing to parse")
+			ctx.WithError(err).Fatal("Flag error")
 		} else if newURI != "" {
 			edited = true
 			client.URI = newURI
@@ -57,7 +57,7 @@ var clientEditCmd = &cobra.Command{
 
 		err = account.EditOAuthClient(name, client)
 		if err != nil {
-			ctx.WithError(err).Fatal("Couldn't edit OAuth client")
+			ctx.WithError(err).Fatal("Could not edit OAuth client")
 		}
 
 		ctx.Info("OAuth client edited")

--- a/ttnctl/cmd/clients_list.go
+++ b/ttnctl/cmd/clients_list.go
@@ -1,0 +1,57 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/TheThingsNetwork/ttn/ttnctl/util"
+	"github.com/gosuri/uitable"
+	"github.com/spf13/cobra"
+)
+
+var clientListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List OAuth clients",
+	Long:  "ttnctl clients list fetches and shows all the owned OAuth clients",
+	Example: `$ ttnctl clients list
+  INFO Found one OAuth client:
+
+        Name                    Description             URI                                                          Secret                                                          Scope                        Grants
+0       ttn-console             TTN Console			    https://console.thethingsnetwork.org/oauth/callback          156a7c34fbd156d333f53b08ab6015b20b558818148a901927bb3f5b19fe    [profile apps gateways]      [authorization_code refresh_token]
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		account := util.GetAccount(ctx)
+
+		clients, err := account.ListOAuthClients()
+		if err != nil {
+			ctx.WithError(err).Fatal("Failed to fetch the OAuth clients")
+		}
+
+		switch len(clients) {
+		case 0:
+			ctx.Info("You don't have any OAuth client")
+			return
+		case 1:
+			ctx.Info("Found one OAuth client:")
+		default:
+			ctx.Infof("Found %d applications:", len(clients))
+		}
+
+		table := uitable.New()
+		table.MaxColWidth = 70
+		table.AddRow("", "Name", "Description", "URI", "Secret", "Scope", "Grants")
+		for i, client := range clients {
+			table.AddRow(i, client.Name, client.Description, client.URI, client.Secret, client.Scope, client.Grants)
+		}
+
+		fmt.Println()
+		fmt.Println(table)
+		fmt.Println()
+	},
+}
+
+func init() {
+	clientsCmd.AddCommand(clientListCmd)
+}

--- a/ttnctl/cmd/clients_list.go
+++ b/ttnctl/cmd/clients_list.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/TheThingsNetwork/ttn/ttnctl/util"
 	"github.com/gosuri/uitable"

--- a/ttnctl/cmd/clients_request.go
+++ b/ttnctl/cmd/clients_request.go
@@ -29,9 +29,13 @@ var clientRequestCmd = &cobra.Command{
 			ctx.WithError(err).Fatal("Error with URI")
 		}
 
-		scope, err := cmd.Flags().GetStringSlice("scope")
+		scopes := make([]string, 0)
+		strScopes, err := cmd.Flags().GetStringSlice("scope")
 		if err != nil {
 			ctx.WithError(err).Fatal("Could not parse scope")
+		}
+		for _, strScope := range strScopes {
+			scopes = append(scopes, strScope)
 		}
 
 		strGrants, err := cmd.Flags().GetStringSlice("grants")
@@ -45,13 +49,15 @@ var clientRequestCmd = &cobra.Command{
 
 		account := util.GetAccount(ctx)
 
-		_, err = account.CreateOAuthClient(&accountlib.OAuthClient{
+		request := accountlib.OAuthClient{
 			Name:        name,
 			Description: description,
 			URI:         uri,
 			Grants:      grants,
-			Scope:       scope,
-		})
+			Scope:       scopes,
+		}
+
+		_, err = account.CreateOAuthClient(&request)
 		if err != nil {
 			ctx.WithError(err).Fatal("Could not request OAuth Client")
 		}

--- a/ttnctl/cmd/clients_request.go
+++ b/ttnctl/cmd/clients_request.go
@@ -1,0 +1,73 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package cmd
+
+import (
+	accountlib "github.com/TheThingsNetwork/go-account-lib/account"
+	"github.com/TheThingsNetwork/ttn/ttnctl/util"
+	"github.com/spf13/cobra"
+)
+
+var clientRequestCmd = &cobra.Command{
+	Use:   "request [Name] [Description]",
+	Short: "Request a client",
+	Long:  "ttnctl clients request can be used to request an OAuth client",
+	Example: `$ ttnctl clients request oauthClient "Client used to consult and edit gateway information" --uri "https://gateways.thethings.network/oauth/callback" --scope "profile,gateways" --grants "authorization_code,refresh_token"
+  INFO OAuth client requested OAuthClientName=oauthClient
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		assertArgsLength(cmd, args, 1, 2)
+
+		var name = args[0]
+		var description string
+		if len(args) >= 2 {
+			description = args[1]
+		}
+
+		ctx = ctx.WithField("OAuthClientName", name)
+
+		uri, err := cmd.Flags().GetString("uri")
+		if err != nil {
+			ctx.WithError(err).Fatal("Error with URI")
+		}
+
+		scope, err := cmd.Flags().GetStringSlice("scope")
+		if err != nil {
+			ctx.WithError(err).Fatal("Could not parse scope")
+		}
+
+		strGrants, err := cmd.Flags().GetStringSlice("grants")
+		if err != nil {
+			ctx.WithError(err).Fatal("Could not parse grants")
+		}
+		grants := make([]accountlib.Grant, 0)
+		for _, strGrant := range strGrants {
+			grants = append(grants, accountlib.Grant(strGrant))
+		}
+
+		account := util.GetAccount(ctx)
+
+		_, err = account.CreateOAuthClient(&accountlib.OAuthClient{
+			Name:        name,
+			Description: description,
+			URI:         uri,
+			Grants:      grants,
+			Scope:       scope,
+		})
+		if err != nil {
+			ctx.WithError(err).Fatal("Could not request OAuth Client")
+		}
+
+		util.ForceRefreshToken(ctx)
+
+		ctx.Info("OAuth client requested")
+	},
+}
+
+func init() {
+	clientsCmd.AddCommand(clientRequestCmd)
+	clientRequestCmd.Flags().String("uri", "", "Pass a callback URI for the OAuth client")
+	clientRequestCmd.Flags().StringSlice("scope", []string{}, "Scopes requested for the OAuth client")
+	clientRequestCmd.Flags().StringSlice("grants", []string{}, "Grants requested for the OAuth client")
+}

--- a/ttnctl/cmd/clients_request.go
+++ b/ttnctl/cmd/clients_request.go
@@ -12,18 +12,15 @@ import (
 var clientRequestCmd = &cobra.Command{
 	Use:   "request [Name] [Description]",
 	Short: "Request a client",
-	Long:  "ttnctl clients request can be used to request an OAuth client",
-	Example: `$ ttnctl clients request oauthClient "Client used to consult and edit gateway information" --uri "https://gateways.thethings.network/oauth/callback" --scope "profile,gateways" --grants "authorization_code,refresh_token"
-  INFO OAuth client requested OAuthClientName=oauthClient
+	Long:  "ttnctl clients request can be used to request an OAuth client from the network staff.",
+	Example: `$ ttnctl clients request my-gateway-editor "Client used to consult and edit gateway information" --uri "https://mygatewayclient.org/oauth/callback" --scope "profile,gateways" --grants "authorization_code,refresh_token"
+  INFO OAuth client requested OAuthClientName=my-gateway-editor
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		assertArgsLength(cmd, args, 1, 2)
+		assertArgsLength(cmd, args, 2, 2)
 
 		var name = args[0]
-		var description string
-		if len(args) >= 2 {
-			description = args[1]
-		}
+		var description = args[1]
 
 		ctx = ctx.WithField("OAuthClientName", name)
 


### PR DESCRIPTION
With this PR, `ttnctl` integrates OAuth client management options.
* `request`: request an OAuth client. After this command is executed, the user receives an e-mail when his/her OAuth client is accepted or rejected. e.g.:
```
ttnctl clients request oauthclient --scope "profile,gateways"`
  INFO OAuth client requested OAuthClientName=oauthclient
```
* `edit`: edit the general information (name, description...) of an existing OAuth client. e.g.:
```
ttnctl clients edit oauthClient1 --name oauthclient-new-name --description "OAuth client used by the console"
  INFO Retrieving OAuth client...               OAuthClientID=oauthClient1
  INFO Retrieved OAuth client                   OAuthClientID=oauthClient1
  INFO OAuth client updated                     OAuthClientID=oauthclient-new-name
```
* `list`: list all owned OAuth clients, and shows it in the same kind of display as `ttnctl applications list`. e.g.:
```
ttnctl clients list
  INFO Found one OAuth client:

        Name                    Description             URI                                                          Secret                                                          Scope                        Grants
0       ttn-console             TTN Console			    https://console.thethingsnetwork.org/oauth/callback 156a7c34fbd156d333f53b08ab6015b20b558818148a901927bb3f5b19fe    [profile apps gateways]      [authorization_code refresh_token]
```
* `delete`: delete an OAuth client
```
ttnctl clients delete oauthclient1
  INFO OAuth client removed successfully OAuthClientName=oauthclient1
```