### PR TITLE
Feature/amqp device events consumer

### DIFF
--- a/amqp/event.go
+++ b/amqp/event.go
@@ -17,6 +17,9 @@ type AppEventHandler func(sub Subscriber, appID string, eventType types.EventTyp
 // DeviceEventHandler is called for events
 type DeviceEventHandler func(sub Subscriber, appID string, devID string, eventType types.EventType, payload []byte)
 
+// EventHandler is called to handle events
+type EventHandler func(subscriber Subscriber, appID string, devID string, req types.DeviceEvent)
+
 // PublishAppEvent publishes an event to the topic for application events of the given type
 // it will marshal the payload to json
 func (c *DefaultPublisher) PublishAppEvent(appID string, eventType types.EventType, payload interface{}) error {
@@ -31,9 +34,9 @@ func (c *DefaultPublisher) PublishAppEvent(appID string, eventType types.EventTy
 
 // PublishDeviceEvent publishes an event to the topic for device events of the given type
 // it will marshal the payload to json
-func (c *DefaultPublisher) PublishDeviceEvent(appID string, devID string, eventType types.EventType, payload interface{}) error {
-	key := DeviceKey{appID, devID, DeviceEvents, string(eventType)}
-	msg, err := json.Marshal(payload)
+func (c *DefaultPublisher) PublishDeviceEvent(event types.DeviceEvent) error {
+	key := DeviceKey{event.AppID, event.DevID, DeviceEvents, string(event.Event)}
+	msg, err := json.Marshal(event)
 	if err != nil {
 		return fmt.Errorf("Unable to marshal the message payload: %s", err)
 	}

--- a/amqp/event.go
+++ b/amqp/event.go
@@ -11,14 +11,11 @@ import (
 	"github.com/TheThingsNetwork/ttn/core/types"
 )
 
-// AppEventHandler is called for events
+// AppEventHandler is called to handle application events
 type AppEventHandler func(sub Subscriber, appID string, eventType types.EventType, payload []byte)
 
-// DeviceEventHandler is called for events
-type DeviceEventHandler func(sub Subscriber, appID string, devID string, eventType types.EventType, payload []byte)
-
-// EventHandler is called to handle events
-type EventHandler func(subscriber Subscriber, appID string, devID string, req types.DeviceEvent)
+// DeviceEventHandler is called to handle events
+type DeviceEventHandler func(subscriber Subscriber, appID string, devID string, event types.DeviceEvent)
 
 // PublishAppEvent publishes an event to the topic for application events of the given type
 // it will marshal the payload to json
@@ -70,8 +67,14 @@ func (s *DefaultSubscriber) SubscribeDeviceEvents(appID string, devID string, ev
 		return err
 	}
 	go func() {
+		event := &types.DeviceEvent{}
 		for letter := range deliveries {
-			handler(s, appID, devID, types.EventType(eventType), letter.Body)
+			err := json.Unmarshal(letter.Body, event)
+			if err != nil {
+				s.ctx.WithError(err).Warn("Could not unmarshall device event")
+				continue
+			}
+			handler(s, appID, devID, *event)
 		}
 	}()
 	return nil

--- a/amqp/event_test.go
+++ b/amqp/event_test.go
@@ -64,11 +64,11 @@ func TestPublishSubscribeDeviceEvents(t *testing.T) {
 	var wg WaitGroup
 	wg.Add(1)
 	err = s.SubscribeDeviceEvents("app-id", "dev-id", "some-event",
-		func(_ Subscriber, appID string, devID string, eventType types.EventType, payload []byte) {
+		func(subscriber Subscriber, appID string, devID string, event types.DeviceEvent) {
 			a.So(appID, ShouldEqual, "app-id")
 			a.So(devID, ShouldEqual, "dev-id")
-			a.So(eventType, ShouldEqual, "some-event")
-			a.So(string(payload), ShouldEqual, `"payload"`)
+			a.So(event.Event, ShouldEqual, "some-event")
+			a.So(event.Data.(string), ShouldEqual, "payload")
 			wg.Done()
 		})
 	a.So(err, ShouldBeNil)

--- a/amqp/event_test.go
+++ b/amqp/event_test.go
@@ -4,11 +4,12 @@
 package amqp
 
 import (
+	"testing"
+	"time"
+
 	"github.com/TheThingsNetwork/ttn/core/types"
 	. "github.com/TheThingsNetwork/ttn/utils/testing"
 	. "github.com/smartystreets/assertions"
-	"testing"
-	"time"
 )
 
 func TestPublishSubscribeAppEvents(t *testing.T) {
@@ -71,7 +72,12 @@ func TestPublishSubscribeDeviceEvents(t *testing.T) {
 			wg.Done()
 		})
 	a.So(err, ShouldBeNil)
-	p.PublishDeviceEvent("app-id", "dev-id", "some-event", "payload")
+	p.PublishDeviceEvent(types.DeviceEvent{
+		AppID: "app-id",
+		DevID: "dev-id",
+		Event: "some-event",
+		Data:  "payload",
+	})
 	err = wg.WaitFor(time.Millisecond * 200)
 	a.So(err, ShouldBeNil)
 }

--- a/amqp/publisher.go
+++ b/amqp/publisher.go
@@ -16,7 +16,7 @@ type Publisher interface {
 
 	PublishUplink(dataUp types.UplinkMessage) error
 	PublishDownlink(dataDown types.DownlinkMessage) error
-	PublishDeviceEvent(appID string, devID string, eventType types.EventType, payload interface{}) error
+	PublishDeviceEvent(event types.DeviceEvent) error
 	PublishAppEvent(appID string, eventType types.EventType, payload interface{}) error
 }
 

--- a/amqp/routing_keys.go
+++ b/amqp/routing_keys.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 )
 
-const simpleWildcard = "*"
-const wildcard = "#"
+const SimpleWildcard = "*"
+const Wildcard = "#"
 
 // DeviceKeyType represents the type of a device topic
 type DeviceKeyType string
@@ -38,11 +38,11 @@ func ParseDeviceKey(key string) (*DeviceKey, error) {
 		return nil, fmt.Errorf("Invalid key format")
 	}
 	var appID string
-	if matches[1] != simpleWildcard {
+	if matches[1] != SimpleWildcard {
 		appID = matches[1]
 	}
 	var devID string
-	if matches[3] != simpleWildcard {
+	if matches[3] != SimpleWildcard {
 		devID = matches[3]
 	}
 	keyType := DeviceKeyType(matches[4])
@@ -55,16 +55,16 @@ func ParseDeviceKey(key string) (*DeviceKey, error) {
 
 // String implements the Stringer interface
 func (t DeviceKey) String() string {
-	appID := simpleWildcard
+	appID := SimpleWildcard
 	if t.AppID != "" {
 		appID = t.AppID
 	}
-	devID := simpleWildcard
+	devID := SimpleWildcard
 	if t.DevID != "" {
 		devID = t.DevID
 	}
 	if t.Type == DeviceEvents && t.Field == "" {
-		t.Field = wildcard
+		t.Field = Wildcard
 	}
 	key := fmt.Sprintf("%s.%s.%s.%s", appID, "devices", devID, t.Type)
 	if t.Type == DeviceEvents && t.Field != "" {
@@ -96,7 +96,7 @@ func ParseApplicationKey(key string) (*ApplicationKey, error) {
 		return nil, fmt.Errorf("Invalid key format")
 	}
 	var appID string
-	if matches[1] != simpleWildcard {
+	if matches[1] != SimpleWildcard {
 		appID = matches[1]
 	}
 	keyType := ApplicationKeyType(matches[2])
@@ -109,12 +109,12 @@ func ParseApplicationKey(key string) (*ApplicationKey, error) {
 
 // String implements the Stringer interface
 func (t ApplicationKey) String() string {
-	appID := simpleWildcard
+	appID := SimpleWildcard
 	if t.AppID != "" {
 		appID = t.AppID
 	}
 	if t.Type == AppEvents && t.Field == "" {
-		t.Field = wildcard
+		t.Field = Wildcard
 	}
 	key := fmt.Sprintf("%s.%s", appID, t.Type)
 	if t.Type == AppEvents && t.Field != "" {

--- a/amqp/subscriber.go
+++ b/amqp/subscriber.go
@@ -30,7 +30,7 @@ type Subscriber interface {
 	SubscribeDeviceUplink(appID, devID string, handler UplinkHandler) error
 	SubscribeAppUplink(appID string, handler UplinkHandler) error
 	SubscribeUplink(handler UplinkHandler) error
-	ConsumeMessages(queue string, uplinkHandler UplinkHandler, eventHandler EventHandler) error
+	ConsumeMessages(queue string, uplinkHandler UplinkHandler, eventHandler DeviceEventHandler) error
 
 	SubscribeDeviceDownlink(appID, devID string, handler DownlinkHandler) error
 	SubscribeAppDownlink(appID string, handler DownlinkHandler) error
@@ -147,7 +147,7 @@ func (s *DefaultSubscriber) subscribe(key string) (<-chan AMQP.Delivery, error) 
 
 // ConsumeMessages consumes all messages in a specific queue and try to handle them as uplinks or events depending on the
 // routing key.
-func (s *DefaultSubscriber) ConsumeMessages(queue string, uplinkHandler UplinkHandler, eventHandler EventHandler) error {
+func (s *DefaultSubscriber) ConsumeMessages(queue string, uplinkHandler UplinkHandler, eventHandler DeviceEventHandler) error {
 	messages, err := s.consume(s.name)
 	if err != nil {
 		return err
@@ -157,9 +157,9 @@ func (s *DefaultSubscriber) ConsumeMessages(queue string, uplinkHandler UplinkHa
 }
 
 // handleMessages consume AMQP.Delivery on a channel and call the uplinkHandler and eventHandler respectively for
-// device uplinks and device events. Deliveries won't be acknowledged is the routing key contain unknown fields or their
+// device uplinks and device events. Deliveries won't be acknowledged if the routing key contain unknown fields or their
 // body cannot be parsed.
-func (s *DefaultSubscriber) handleMessages(messages <-chan AMQP.Delivery, uplinkHandler UplinkHandler, eventHandler EventHandler) {
+func (s *DefaultSubscriber) handleMessages(messages <-chan AMQP.Delivery, uplinkHandler UplinkHandler, eventHandler DeviceEventHandler) {
 	for delivery := range messages {
 		pins := strings.Split(delivery.RoutingKey, ".")
 		if pins[3] == string(DeviceEvents) {

--- a/amqp/subscriber.go
+++ b/amqp/subscriber.go
@@ -4,7 +4,9 @@
 package amqp
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/TheThingsNetwork/ttn/core/types"
 	AMQP "github.com/streadway/amqp"
@@ -28,7 +30,7 @@ type Subscriber interface {
 	SubscribeDeviceUplink(appID, devID string, handler UplinkHandler) error
 	SubscribeAppUplink(appID string, handler UplinkHandler) error
 	SubscribeUplink(handler UplinkHandler) error
-	ConsumeUplink(queue string, handler UplinkHandler) error
+	ConsumeMessages(queue string, uplinkHandler UplinkHandler, eventHandler EventHandler) error
 
 	SubscribeDeviceDownlink(appID, devID string, handler DownlinkHandler) error
 	SubscribeAppDownlink(appID string, handler DownlinkHandler) error
@@ -141,4 +143,45 @@ func (s *DefaultSubscriber) subscribe(key string) (<-chan AMQP.Delivery, error) 
 		return nil, err
 	}
 	return s.consume(queue)
+}
+
+// ConsumeMessages consumes all messages in a specific queue and try to handle them as uplinks or events depending on the
+// routing key.
+func (s *DefaultSubscriber) ConsumeMessages(queue string, uplinkHandler UplinkHandler, eventHandler EventHandler) error {
+	messages, err := s.consume(s.name)
+	if err != nil {
+		return err
+	}
+	go s.handleMessages(messages, uplinkHandler, eventHandler)
+	return nil
+}
+
+// handleMessages consume AMQP.Delivery on a channel and call the uplinkHandler and eventHandler respectively for
+// device uplinks and device events. Deliveries won't be acknowledged is the routing key contain unknown fields or their
+// body cannot be parsed.
+func (s *DefaultSubscriber) handleMessages(messages <-chan AMQP.Delivery, uplinkHandler UplinkHandler, eventHandler EventHandler) {
+	for delivery := range messages {
+		pins := strings.Split(delivery.RoutingKey, ".")
+		if pins[3] == string(DeviceEvents) {
+			event := &types.DeviceEvent{}
+			if err := json.Unmarshal(delivery.Body, event); err != nil {
+				s.ctx.Warnf("Could not unmarshal device event (%s)", err)
+				continue
+			}
+			eventHandler(s, event.AppID, event.DevID, *event)
+		} else if pins[3] == string(DeviceUplink) {
+			dataUp := &types.UplinkMessage{}
+			if err := json.Unmarshal(delivery.Body, dataUp); err != nil {
+				s.ctx.Warnf("Could not unmarshal device uplink (%s)", err)
+				continue
+			}
+			uplinkHandler(s, dataUp.AppID, dataUp.DevID, *dataUp)
+		} else {
+			s.ctx.Warnf("Unknown routing key (%s)", delivery.RoutingKey)
+			continue
+		}
+		if err := delivery.Ack(false); err != nil {
+			s.ctx.Warnf("Could not acknowledge message (%s)", err)
+		}
+	}
 }

--- a/amqp/subscriber_test.go
+++ b/amqp/subscriber_test.go
@@ -4,8 +4,10 @@
 package amqp
 
 import (
+	"sync"
 	"testing"
 
+	"github.com/TheThingsNetwork/ttn/core/types"
 	. "github.com/smartystreets/assertions"
 )
 
@@ -42,4 +44,61 @@ func TestQueueOps(t *testing.T) {
 	err = s.QueueBind(name, key)
 	a.So(err, ShouldBeNil)
 	defer s.QueueUnbind(name, key)
+}
+
+func TestSubscriberConsume(t *testing.T) {
+	a := New(t)
+	c := NewClient(getLogger(t, "TestSubscriberConsume"), "guest", "guest", host)
+	err := c.Connect()
+	a.So(err, ShouldBeNil)
+	defer c.Disconnect()
+
+	s := c.NewSubscriber("amq.topic", "", false, true)
+	err = s.Open()
+	a.So(err, ShouldBeNil)
+	defer s.Close()
+
+	name, err := s.QueueDeclare()
+	a.So(err, ShouldBeNil)
+	a.So(name, ShouldNotBeEmpty)
+
+	key := DeviceKey{
+		DevID: SimpleWildcard,
+		AppID: "TestSubscriberConsume",
+		Type:  Wildcard,
+	}.String()
+	err = s.QueueBind(name, key)
+	a.So(err, ShouldBeNil)
+	defer s.QueueUnbind(name, key)
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	s.ConsumeMessages(name, func(subscriber Subscriber, appID string, devID string, req types.UplinkMessage) {
+		a.So(appID, ShouldEqual, "TestSubscriberConsume")
+		a.So(req.PayloadRaw, ShouldResemble, []byte("TestRaw"))
+		wg.Done()
+	}, func(subscriber Subscriber, appID string, devID string, req types.DeviceEvent) {
+		a.So(devID, ShouldEqual, "TestSubscriberConsumeDevice")
+		a.So(req.Event, ShouldEqual, types.ActivationEvent)
+		wg.Done()
+	})
+	p := c.NewPublisher("amq.topic")
+	err = p.Open()
+	a.So(err, ShouldBeNil)
+	defer p.Close()
+
+	err = p.PublishUplink(types.UplinkMessage{
+		AppID:      "TestSubscriberConsume",
+		DevID:      "TestSubscriberConsumeDevice",
+		PayloadRaw: []byte("TestRaw"),
+	})
+	a.So(err, ShouldBeNil)
+
+	err = p.PublishDeviceEvent(types.DeviceEvent{
+		AppID: "TestSubscriberConsume",
+		DevID: "TestSubscriberConsumeDevice",
+		Event: types.ActivationEvent,
+	})
+	a.So(err, ShouldBeNil)
+	wg.Wait()
 }

--- a/amqp/uplink.go
+++ b/amqp/uplink.go
@@ -8,9 +8,8 @@ import (
 	"fmt"
 	"time"
 
-	AMQP "github.com/streadway/amqp"
-
 	"github.com/TheThingsNetwork/ttn/core/types"
+	AMQP "github.com/streadway/amqp"
 )
 
 // UplinkHandler is called for uplink messages

--- a/amqp/uplink.go
+++ b/amqp/uplink.go
@@ -52,17 +52,6 @@ func (s *DefaultSubscriber) SubscribeDeviceUplink(appID, devID string, handler U
 	return nil
 }
 
-// ConsumeUplink consumes uplink messages in a specific queue
-func (s *DefaultSubscriber) ConsumeUplink(queue string, handler UplinkHandler) error {
-	messages, err := s.consume(s.name)
-	if err != nil {
-		return err
-	}
-
-	go s.handleUplink(messages, handler)
-	return nil
-}
-
 // SubscribeAppUplink subscribes to all uplink messages for the given application
 func (s *DefaultSubscriber) SubscribeAppUplink(appID string, handler UplinkHandler) error {
 	return s.SubscribeDeviceUplink(appID, "", handler)

--- a/core/handler/amqp.go
+++ b/core/handler/amqp.go
@@ -118,7 +118,7 @@ func (h *handler) HandleAMQP(username, password, host, exchange, downlinkQueue s
 					ctx.WithError(err).Warn("Could not publish App Event")
 				}
 			} else {
-				if err := publisher.PublishDeviceEvent(event.AppID, event.DevID, event.Event, event.Data); err != nil {
+				if err := publisher.PublishDeviceEvent(*event); err != nil {
 					ctx.WithError(err).Warn("Could not publish Device Event")
 				}
 			}

--- a/core/handler/amqp_test.go
+++ b/core/handler/amqp_test.go
@@ -92,13 +92,13 @@ func TestHandleAMQP(t *testing.T) {
 		err = s.Open()
 		a.So(err, ShouldBeNil)
 		defer s.Close()
-		err = s.SubscribeDeviceEvents(appID, devID, "", func(_ amqp.Subscriber, r_appID string, r_devID string, r_event types.EventType, evt []byte) {
-			a.So(r_appID, ShouldEqual, appID)
-			a.So(r_devID, ShouldEqual, devID)
-			wg.Done()
-		})
+		err = s.SubscribeDeviceEvents(appID, devID, "",
+			func(subscriber amqp.Subscriber, r_appID string, r_devID string, event types.DeviceEvent) {
+				a.So(r_appID, ShouldEqual, appID)
+				a.So(r_devID, ShouldEqual, devID)
+				wg.Done()
+			})
 		a.So(err, ShouldBeNil)
-
 		h.amqpEvent <- &types.DeviceEvent{
 			DevID: devID,
 			AppID: appID,

--- a/core/types/event.go
+++ b/core/types/event.go
@@ -40,10 +40,10 @@ func (e EventType) Data() interface{} {
 
 // DeviceEvent represents an application-layer event message for a device event
 type DeviceEvent struct {
-	AppID string
-	DevID string
-	Event EventType
-	Data  interface{}
+	AppID string      `json:"app_id"`
+	DevID string      `json:"dev_id"`
+	Event EventType   `json:"event"`
+	Data  interface{} `json:"data"`
 }
 
 // ErrorEventData is added to error events


### PR DESCRIPTION
This pull request add the device events handling in the generic AMQP consumer.

It is mainly aimed for the integration since they listen to any messages incoming on a AMQP queue. It will give them the possibility to react to device events.

It use the routing key in the delivery to determine if the message is an event or an uplinks.
Since they can be many different messages on one amqp queue the consumer do a few checks to be sure the routing key is valid and destined to him. Otherwise the delivery is not acknowledged so it can be send to another consumer. 

Changes in the prototypes of some functions have been made for ease and consistency.