### PR TITLE
Add support for ADR on US_902_928 band

### DIFF
--- a/core/band/adr.go
+++ b/core/band/adr.go
@@ -13,6 +13,7 @@ var demodulationFloor = map[string]float32{
 	"SF11BW125": -17.5,
 	"SF12BW125": -20,
 	"SF7BW250":  -4.5,
+	"SF8BW500":  -4,
 }
 
 func linkMargin(dataRate string, snr float32) float32 {

--- a/core/band/adr.go
+++ b/core/band/adr.go
@@ -29,6 +29,7 @@ type ADRConfig struct {
 	MaxDataRate int
 	MinTXPower  int
 	MaxTXPower  int
+	StepTXPower int
 }
 
 // ErrADRUnavailable is returned when ADR is not available
@@ -52,9 +53,10 @@ func (f *FrequencyPlan) ADRSettings(dataRate string, txPower int, snr float32, d
 		nStep--
 	}
 
-	// Decrease the Tx power by 3 for each step, until min reached
+	nStep = int(float32(nStep*3) / float32(f.ADR.StepTXPower))
+	// Decrease the Tx power by f.ADR.StepTXPower for each step, until min reached
 	for nStep > 0 && txPower > f.ADR.MinTXPower {
-		txPower -= 3
+		txPower -= f.ADR.StepTXPower
 		nStep--
 	}
 	if txPower < f.ADR.MinTXPower {
@@ -63,7 +65,7 @@ func (f *FrequencyPlan) ADRSettings(dataRate string, txPower int, snr float32, d
 
 	// Increase the Tx power by 3 for each step, until max reached
 	for nStep < 0 && txPower < f.ADR.MaxTXPower {
-		txPower += 3
+		txPower += f.ADR.StepTXPower
 		nStep++
 	}
 	if txPower > f.ADR.MaxTXPower {

--- a/core/band/adr_test.go
+++ b/core/band/adr_test.go
@@ -20,40 +20,83 @@ func TestADRSettings(t *testing.T) {
 		a.So(err, ShouldBeNil)
 		a.So(dr, ShouldEqual, "SF10BW125")
 		a.So(tx, ShouldEqual, 14)
+		_, err = eu.GetTxPowerIndexFor(tx)
+		a.So(err, ShouldBeNil)
 	}
 	{
 		dr, tx, err := eu.ADRSettings("SF7BW125", 14, 9, defaultMargin)
 		a.So(err, ShouldBeNil)
 		a.So(dr, ShouldEqual, "SF7BW125")
 		a.So(tx, ShouldEqual, 8)
+		_, err = eu.GetTxPowerIndexFor(tx)
+		a.So(err, ShouldBeNil)
 	}
 	{
 		dr, tx, err := eu.ADRSettings("SF7BW125", 4, 9, defaultMargin)
 		a.So(err, ShouldBeNil)
 		a.So(dr, ShouldEqual, "SF7BW125")
 		a.So(tx, ShouldEqual, 2)
+		_, err = eu.GetTxPowerIndexFor(tx)
+		a.So(err, ShouldBeNil)
 	}
 	{
 		dr, tx, err := eu.ADRSettings("SF7BW125", 9, -6, defaultMargin)
 		a.So(err, ShouldBeNil)
 		a.So(dr, ShouldEqual, "SF7BW125")
 		a.So(tx, ShouldEqual, 14)
+		_, err = eu.GetTxPowerIndexFor(tx)
+		a.So(err, ShouldBeNil)
 	}
 	{
 		dr, tx, err := eu.ADRSettings("SF7BW125", 8, -6, defaultMargin)
 		a.So(err, ShouldBeNil)
 		a.So(dr, ShouldEqual, "SF7BW125")
 		a.So(tx, ShouldEqual, 14)
+		_, err = eu.GetTxPowerIndexFor(tx)
+		a.So(err, ShouldBeNil)
 	}
 
 	us, _ := Get("US_902_928")
 	{
-		dr, tx, err := us.ADRSettings("SF10BW125", 18, 30, defaultMargin)
+		dr, tx, err := us.ADRSettings("SF7BW125", 10, -6, defaultMargin)
 		a.So(err, ShouldBeNil)
-		a.So(dr, ShouldEqual, "SF8BW500")
-		a.So(tx, ShouldEqual, 20)
+		a.So(dr, ShouldEqual, "SF7BW125")
+		a.So(tx, ShouldEqual, 16)
+		_, err = us.GetTxPowerIndexFor(tx)
+		a.So(err, ShouldBeNil)
 	}
-
+	{
+		dr, tx, err := us.ADRSettings("SF7BW125", 16, -6, defaultMargin)
+		a.So(err, ShouldBeNil)
+		a.So(dr, ShouldEqual, "SF7BW125")
+		a.So(tx, ShouldEqual, 20)
+		_, err = us.GetTxPowerIndexFor(tx)
+		a.So(err, ShouldBeNil)
+	}
+	{
+		dr, tx, err := us.ADRSettings("SF7BW125", 20, -6, defaultMargin)
+		a.So(err, ShouldBeNil)
+		a.So(dr, ShouldEqual, "SF7BW125")
+		a.So(tx, ShouldEqual, 20)
+		_, err = us.GetTxPowerIndexFor(tx)
+		a.So(err, ShouldBeNil)
+	}
+	{
+		dr, tx, err := us.ADRSettings("SF7BW125", 14, 6, defaultMargin)
+		a.So(err, ShouldBeNil)
+		a.So(dr, ShouldEqual, "SF7BW125")
+		a.So(tx, ShouldEqual, 12)
+		_, err = us.GetTxPowerIndexFor(tx)
+		a.So(err, ShouldBeNil)
+	}
+	{
+		dr, tx, err := us.ADRSettings("SF7BW125", 12, 9, defaultMargin)
+		a.So(err, ShouldBeNil)
+		a.So(dr, ShouldEqual, "SF7BW125")
+		a.So(tx, ShouldEqual, 10)
+		_, err = us.GetTxPowerIndexFor(tx)
+		a.So(err, ShouldBeNil)
+	}
 	cn, _ := Get("CN_470_510")
 	{
 		_, _, err := cn.ADRSettings("SF10BW125", 14, -3, defaultMargin)
@@ -65,10 +108,6 @@ func TestADRSettings(t *testing.T) {
 		// Invalid datarate (there is no SF19)
 		_, _, err := eu.ADRSettings("SF19BW125", 14, -3, defaultMargin)
 		a.So(err, ShouldNotBeNil)
-
-		// Invalid datarate (there is no SF12 in US)
-		us, _ := Get("US_902_928")
-		us.ADR = new(ADRConfig)
 		_, _, err = us.ADRSettings("SF12BW125", 14, -3, defaultMargin)
 		a.So(err, ShouldNotBeNil)
 	}

--- a/core/band/adr_test.go
+++ b/core/band/adr_test.go
@@ -50,8 +50,8 @@ func TestADRSettings(t *testing.T) {
 	{
 		dr, tx, err := us.ADRSettings("SF10BW125", 18, 30, defaultMargin)
 		a.So(err, ShouldBeNil)
-		a.So(dr, ShouldEqual,"SF8BW500")
-		a.So(tx, ShouldEqual,20)
+		a.So(dr, ShouldEqual, "SF8BW500")
+		a.So(tx, ShouldEqual, 20)
 	}
 
 	cn, _ := Get("CN_470_510")

--- a/core/band/adr_test.go
+++ b/core/band/adr_test.go
@@ -48,7 +48,15 @@ func TestADRSettings(t *testing.T) {
 
 	us, _ := Get("US_902_928")
 	{
-		_, _, err := us.ADRSettings("SF10BW125", 14, -3, defaultMargin)
+		dr, tx, err := us.ADRSettings("SF10BW125", 18, 30, defaultMargin)
+		a.So(err, ShouldBeNil)
+		a.So(dr, ShouldEqual,"SF8BW500")
+		a.So(tx, ShouldEqual,20)
+	}
+
+	cn, _ := Get("CN_470_510")
+	{
+		_, _, err := cn.ADRSettings("SF10BW125", 14, -3, defaultMargin)
 		a.So(err, ShouldNotBeNil)
 	}
 

--- a/core/band/band.go
+++ b/core/band/band.go
@@ -87,21 +87,16 @@ func Get(region string) (frequencyPlan FrequencyPlan, err error) {
 		}
 		frequencyPlan.DownlinkChannels = frequencyPlan.UplinkChannels
 		frequencyPlan.CFList = &lorawan.CFList{867100000, 867300000, 867500000, 867700000, 867900000}
-		frequencyPlan.ADR = &ADRConfig{MinDataRate: 0, MaxDataRate: 5, MinTXPower: 2, MaxTXPower: 14}
+		frequencyPlan.ADR = &ADRConfig{MinDataRate: 0, MaxDataRate: 5, MinTXPower: 2, MaxTXPower: 14, StepTXPower: 3}
 	case pb_lorawan.FrequencyPlan_US_902_928.String():
 		frequencyPlan.Band, err = lora.GetConfig(lora.US_902_928, false, lorawan.DwellTime400ms)
-		channelGroups := [](int){1} // Enable 903.9-905.3/200 kHz, 904.6 mHz channels
+		fsb := 1 // Enable 903.9-905.3/200 kHz, 904.6 mHz channels
 		for channel := 0; channel < 72; channel++ {
-			for _, channelGroup := range channelGroups {
-				if (channel < channelGroup*8 || channel >= (channelGroup+1)*8) && channel != channelGroup+64 {
-					frequencyPlan.DisableUplinkChannel(channel)
-				}
+			if (channel < fsb*8 || channel >= (fsb+1)*8) && channel != fsb+64 {
+				frequencyPlan.DisableUplinkChannel(channel)
 			}
 		}
-		// Is there a reason MaxDataRate shouldn't be 4?  I suppose if it was, the number of channels occupied would be
-		// smaller but the device would still be well inside of the FCC limits and spectral efficiency should be
-		// greater.
-		frequencyPlan.ADR = &ADRConfig{MinDataRate: 0, MaxDataRate: 3, MinTXPower: 10, MaxTXPower: 20}
+		frequencyPlan.ADR = &ADRConfig{MinDataRate: 0, MaxDataRate: 3, MinTXPower: 10, MaxTXPower: 20, StepTXPower: 2}
 	case pb_lorawan.FrequencyPlan_CN_779_787.String():
 		frequencyPlan.Band, err = lora.GetConfig(lora.CN_779_787, false, lorawan.DwellTimeNoLimit)
 	case pb_lorawan.FrequencyPlan_EU_433.String():

--- a/core/band/band.go
+++ b/core/band/band.go
@@ -93,7 +93,7 @@ func Get(region string) (frequencyPlan FrequencyPlan, err error) {
 		channelGroups := [](int){1} // Enable 903.9-905.3/200 kHz, 904.6 mHz channels
 		for channel := 0; channel < 72; channel++ {
 			for _, channelGroup := range channelGroups {
-				if (channel < channelGroup * 8 || channel >= (channelGroup + 1) * 8) && channel != channelGroup + 64 {
+				if (channel < channelGroup*8 || channel >= (channelGroup+1)*8) && channel != channelGroup+64 {
 					frequencyPlan.DisableUplinkChannel(channel)
 				}
 			}

--- a/core/band/band.go
+++ b/core/band/band.go
@@ -90,6 +90,18 @@ func Get(region string) (frequencyPlan FrequencyPlan, err error) {
 		frequencyPlan.ADR = &ADRConfig{MinDataRate: 0, MaxDataRate: 5, MinTXPower: 2, MaxTXPower: 14}
 	case pb_lorawan.FrequencyPlan_US_902_928.String():
 		frequencyPlan.Band, err = lora.GetConfig(lora.US_902_928, false, lorawan.DwellTime400ms)
+		channelGroups := [](int){1} // Enable 903.9-905.3/200 kHz, 904.6 mHz channels
+		for channel := 0; channel < 72; channel++ {
+			for _, channelGroup := range channelGroups {
+				if (channel < channelGroup * 8 || channel >= (channelGroup + 1) * 8) && channel != channelGroup + 64 {
+					frequencyPlan.DisableUplinkChannel(channel)
+				}
+			}
+		}
+		// Is there a reason MaxDataRate shouldn't be 4?  I suppose if it was, the number of channels occupied would be
+		// smaller but the device would still be well inside of the FCC limits and spectral efficiency should be
+		// greater.
+		frequencyPlan.ADR = &ADRConfig{MinDataRate: 0, MaxDataRate: 3, MinTXPower: 10, MaxTXPower: 20}
 	case pb_lorawan.FrequencyPlan_CN_779_787.String():
 		frequencyPlan.Band, err = lora.GetConfig(lora.CN_779_787, false, lorawan.DwellTimeNoLimit)
 	case pb_lorawan.FrequencyPlan_EU_433.String():

--- a/core/band/band_test.go
+++ b/core/band/band_test.go
@@ -41,7 +41,7 @@ func TestGet(t *testing.T) {
 		fp, err := Get("US_902_928")
 		a.So(err, ShouldBeNil)
 		a.So(fp.CFList, ShouldBeNil)
-		a.So(fp.ADR, ShouldBeNil)
+		a.So(fp.ADR, ShouldNotBeNil)
 	}
 
 	{

--- a/core/networkserver/adr.go
+++ b/core/networkserver/adr.go
@@ -224,7 +224,7 @@ func getAdrReqPayloads(dev *device.Device, frequencyPlan *band.FrequencyPlan, dr
 					TXPower:  uint8(powerIdx),
 					Redundancy: lorawan.Redundancy{
 						ChMaskCntl: 7,
-						NbRep: uint8(dev.ADR.NbTrans),
+						NbRep:      uint8(dev.ADR.NbTrans),
 					},
 				}, // All 125 kHz OFF ChMask applies to channels 64 to 71
 			}
@@ -249,7 +249,7 @@ func getAdrReqPayloads(dev *device.Device, frequencyPlan *band.FrequencyPlan, dr
 						TXPower:  uint8(powerIdx),
 						Redundancy: lorawan.Redundancy{
 							ChMaskCntl: uint8(chMaskCntl),
-							NbRep: uint8(dev.ADR.NbTrans),
+							NbRep:      uint8(dev.ADR.NbTrans),
 						},
 					}
 

--- a/core/networkserver/adr.go
+++ b/core/networkserver/adr.go
@@ -11,6 +11,7 @@ import (
 	"github.com/TheThingsNetwork/ttn/core/band"
 	"github.com/TheThingsNetwork/ttn/core/networkserver/device"
 	"github.com/brocaar/lorawan"
+	"sort"
 )
 
 // DefaultADRMargin is the default SNR margin for ADR
@@ -168,36 +169,102 @@ func (n *networkServer) handleDownlinkADR(message *pb_broker.DownlinkMessage, de
 
 	// Set MAC command
 	lorawanDownlinkMAC := message.GetMessage().GetLoRaWAN().GetMACPayload()
-	response := &lorawan.LinkADRReqPayload{
-		DataRate: uint8(drIdx),
-		TXPower:  uint8(powerIdx),
-		Redundancy: lorawan.Redundancy{
-			ChMaskCntl: 0, // Different for US/AU
-			NbRep:      uint8(dev.ADR.NbTrans),
-		},
-	}
-	for i, ch := range fp.UplinkChannels { // Different for US/AU
-		for _, dr := range ch.DataRates {
-			if dr == drIdx {
-				response.ChMask[i] = true
-			}
-		}
-	}
-	responsePayload, _ := response.MarshalBinary()
+
+	payloads := getAdrReqPayloads(dev, &fp, drIdx, powerIdx)
 
 	// Remove LinkADRReq if already added
-	fOpts := make([]pb_lorawan.MACCommand, 0, len(lorawanDownlinkMAC.FOpts)+1)
+	fOpts := make([]pb_lorawan.MACCommand, 0, len(lorawanDownlinkMAC.FOpts)+len(payloads))
 	for _, existing := range lorawanDownlinkMAC.FOpts {
 		if existing.CID != uint32(lorawan.LinkADRReq) {
 			fOpts = append(fOpts, existing)
 		}
 	}
-	fOpts = append(fOpts, pb_lorawan.MACCommand{
-		CID:     uint32(lorawan.LinkADRReq),
-		Payload: responsePayload,
-	})
+	for _, payload := range payloads {
+		responsePayload, _ := payload.MarshalBinary()
+		fOpts = append(fOpts, pb_lorawan.MACCommand{
+			CID:     uint32(lorawan.LinkADRReq),
+			Payload: responsePayload,
+		})
+	}
 
 	lorawanDownlinkMAC.FOpts = fOpts
 
 	return nil
+}
+
+func getAdrReqPayloads(dev *device.Device, frequencyPlan *band.FrequencyPlan, drIdx int, powerIdx int) []lorawan.LinkADRReqPayload {
+	payloads := []lorawan.LinkADRReqPayload{}
+	switch dev.ADR.Band {
+	case pb_lorawan.FrequencyPlan_EU_863_870.String():
+		{
+			payloads = []lorawan.LinkADRReqPayload{
+				{
+					DataRate: uint8(drIdx),
+					TXPower:  uint8(powerIdx),
+					Redundancy: lorawan.Redundancy{
+						ChMaskCntl: 0,
+						NbRep:      uint8(dev.ADR.NbTrans),
+					},
+				},
+			}
+			for i, ch := range frequencyPlan.UplinkChannels {
+				for _, dr := range ch.DataRates {
+					if dr == drIdx {
+						payloads[0].ChMask[i] = true
+					}
+				}
+			}
+		}
+	case pb_lorawan.FrequencyPlan_US_902_928.String():
+		{
+			// Adapted from https://github.com/brocaar/lorawan/blob/master/band/band_us902_928.go
+			payloads = []lorawan.LinkADRReqPayload{
+				{
+					DataRate: uint8(drIdx),
+					TXPower:  uint8(powerIdx),
+					Redundancy: lorawan.Redundancy{
+						ChMaskCntl: 7,
+						NbRep: uint8(dev.ADR.NbTrans),
+					},
+				}, // All 125 kHz OFF ChMask applies to channels 64 to 71
+			}
+			channels := frequencyPlan.GetEnabledUplinkChannels()
+			sort.Ints(channels)
+
+			chMaskCntl := -1
+			for _, c := range channels {
+				// use the ChMask of the first LinkADRReqPayload, besides
+				// turning off all 125 kHz this payload contains the ChMask
+				// for the last block of channels.
+				if c >= 64 {
+					payloads[0].ChMask[c%16] = true
+					println("Ch", c, true)
+					continue
+				}
+
+				if c/16 != chMaskCntl {
+					chMaskCntl = c / 16
+					pl := lorawan.LinkADRReqPayload{
+						DataRate: uint8(drIdx),
+						TXPower:  uint8(powerIdx),
+						Redundancy: lorawan.Redundancy{
+							ChMaskCntl: uint8(chMaskCntl),
+							NbRep: uint8(dev.ADR.NbTrans),
+						},
+					}
+
+					// set the channel mask for this block
+					for _, ec := range channels {
+						if ec >= chMaskCntl*16 && ec < (chMaskCntl+1)*16 {
+							pl.ChMask[ec%16] = true
+							println("Ch", c, true)
+
+						}
+					}
+					payloads = append(payloads, pl)
+				}
+			}
+		}
+	}
+	return payloads
 }

--- a/core/networkserver/adr_test.go
+++ b/core/networkserver/adr_test.go
@@ -214,7 +214,7 @@ func TestHandleDownlinkADR(t *testing.T) {
 		// Ch 64-71, All 125 kHz channels off
 		a.So(payload.ChMask[0], ShouldBeFalse) // Channel 64 disabled
 		a.So(payload.ChMask[1], ShouldBeTrue)  // Channel 65 enabled
-		for i := 2; i < 8; i++ { // Channels 66-71 disabled
+		for i := 2; i < 8; i++ {               // Channels 66-71 disabled
 			a.So(payload.ChMask[i], ShouldBeFalse)
 		}
 		payload = new(lorawan.LinkADRReqPayload)
@@ -222,7 +222,7 @@ func TestHandleDownlinkADR(t *testing.T) {
 		a.So(payload.DataRate, ShouldEqual, 3)              // SF7BW125
 		a.So(payload.TXPower, ShouldEqual, 5)               // 20
 		a.So(payload.Redundancy.ChMaskCntl, ShouldEqual, 0) // Channels 0..15
-		for i := 0; i < 8; i++ { // First 8 channels disabled
+		for i := 0; i < 8; i++ {                            // First 8 channels disabled
 			a.So(payload.ChMask[i], ShouldBeFalse)
 		}
 		for i := 8; i < 16; i++ { // Second 8 channels enabled
@@ -241,7 +241,7 @@ func TestHandleDownlinkADR(t *testing.T) {
 		payload.UnmarshalBinary(fOpts[1].Payload)
 		a.So(payload.DataRate, ShouldEqual, 5) // SF7BW125
 		a.So(payload.TXPower, ShouldEqual, 1)  // 14
-		for i := 0; i < 8; i++ { // First 8 channels enabled
+		for i := 0; i < 8; i++ {               // First 8 channels enabled
 			a.So(payload.ChMask[i], ShouldBeTrue)
 		}
 		a.So(payload.ChMask[8], ShouldBeFalse) // 9th channel (FSK) disabled

--- a/core/networkserver/adr_test.go
+++ b/core/networkserver/adr_test.go
@@ -199,24 +199,53 @@ func TestHandleDownlinkADR(t *testing.T) {
 	dev.ADR.Band = "INVALID"
 	shouldReturnError()
 
-	dev.ADR.Band = "US_902_928"
-	nothingShouldHappen()
-
-	dev.ADR.Band = "EU_863_870"
-
-	err := ns.handleDownlinkADR(message, dev)
-	a.So(err, ShouldBeNil)
-	fOpts := message.Message.GetLoRaWAN().GetMACPayload().FOpts
-	a.So(fOpts, ShouldHaveLength, 2)
-	a.So(fOpts[1].CID, ShouldEqual, lorawan.LinkADRReq)
-	payload := new(lorawan.LinkADRReqPayload)
-	payload.UnmarshalBinary(fOpts[1].Payload)
-	a.So(payload.DataRate, ShouldEqual, 5) // SF7BW125
-	a.So(payload.TXPower, ShouldEqual, 1)  // 14
-	for i := 0; i < 8; i++ {               // First 8 channels enabled
-		a.So(payload.ChMask[i], ShouldBeTrue)
+	{
+		dev.ADR.Band = "US_902_928"
+		err := ns.handleDownlinkADR(message, dev)
+		a.So(err, ShouldBeNil)
+		fOpts := message.Message.GetLoRaWAN().GetMACPayload().FOpts
+		a.So(fOpts, ShouldHaveLength, 3)
+		a.So(fOpts[1].CID, ShouldEqual, lorawan.LinkADRReq)
+		payload := new(lorawan.LinkADRReqPayload)
+		payload.UnmarshalBinary(fOpts[1].Payload) // First LinkAdrReq
+		a.So(payload.DataRate, ShouldEqual, 3)    // SF7BW125
+		a.So(payload.TXPower, ShouldEqual, 5)     // 20
+		a.So(payload.Redundancy.ChMaskCntl, ShouldEqual, 7)
+		// Ch 64-71, All 125 kHz channels off
+		a.So(payload.ChMask[0], ShouldBeFalse) // Channel 64 disabled
+		a.So(payload.ChMask[1], ShouldBeTrue)  // Channel 65 enabled
+		for i := 2; i < 8; i++ { // Channels 66-71 disabled
+			a.So(payload.ChMask[i], ShouldBeFalse)
+		}
+		payload = new(lorawan.LinkADRReqPayload)
+		payload.UnmarshalBinary(fOpts[2].Payload)           // Second LinkAdrReq
+		a.So(payload.DataRate, ShouldEqual, 3)              // SF7BW125
+		a.So(payload.TXPower, ShouldEqual, 5)               // 20
+		a.So(payload.Redundancy.ChMaskCntl, ShouldEqual, 0) // Channels 0..15
+		for i := 0; i < 8; i++ { // First 8 channels disabled
+			a.So(payload.ChMask[i], ShouldBeFalse)
+		}
+		for i := 8; i < 16; i++ { // Second 8 channels enabled
+			a.So(payload.ChMask[i], ShouldBeTrue)
+		}
 	}
-	a.So(payload.ChMask[8], ShouldBeFalse) // 9th channel (FSK) disabled
+
+	{
+		dev.ADR.Band = "EU_863_870"
+		err := ns.handleDownlinkADR(message, dev)
+		a.So(err, ShouldBeNil)
+		fOpts := message.Message.GetLoRaWAN().GetMACPayload().FOpts
+		a.So(fOpts, ShouldHaveLength, 2)
+		a.So(fOpts[1].CID, ShouldEqual, lorawan.LinkADRReq)
+		payload := new(lorawan.LinkADRReqPayload)
+		payload.UnmarshalBinary(fOpts[1].Payload)
+		a.So(payload.DataRate, ShouldEqual, 5) // SF7BW125
+		a.So(payload.TXPower, ShouldEqual, 1)  // 14
+		for i := 0; i < 8; i++ { // First 8 channels enabled
+			a.So(payload.ChMask[i], ShouldBeTrue)
+		}
+		a.So(payload.ChMask[8], ShouldBeFalse) // 9th channel (FSK) disabled
+	}
 
 	shouldHaveNbTrans := func(nbTrans int) {
 		a := New(t)
@@ -260,5 +289,4 @@ func TestHandleDownlinkADR(t *testing.T) {
 	message = adrInitDownlinkMessage()
 	dev.ADR.DataRate = "INVALID"
 	shouldReturnError()
-
 }


### PR DESCRIPTION
This pull request adds support for ADR on the US 902-928 band.  The power limits are capped at 20dBm, although the 500kHz channels appear to allow 26dBm.

Related to https://github.com/TheThingsNetwork/ttn/issues/619