### PR TITLE
Mask sensitive information in error messages

### DIFF
--- a/core/networkserver/manager_server.go
+++ b/core/networkserver/manager_server.go
@@ -27,6 +27,9 @@ type networkServerManager struct {
 }
 
 func checkAppRights(claims *claims.Claims, appID string, right types.Right) error {
+	if !claims.AppAccess(appID) {
+		return errors.NewErrPermissionDenied("No access to Application")
+	}
 	if !claims.AppRight(appID, right) {
 		return errors.NewErrPermissionDenied(fmt.Sprintf(`No "%s" rights to Application "%s"`, right, appID))
 	}


### PR DESCRIPTION
- Masking an app ID if the claims do not contain access to the app ID
- Masking an underlying error from the Account Server