### PR TITLE
Filter offline services from Discovery

### DIFF
--- a/cmd/discovery.go
+++ b/cmd/discovery.go
@@ -64,6 +64,7 @@ var discoveryCmd = &cobra.Command{
 		if viper.GetBool("discovery.cache") {
 			discovery.WithCache(announcement.DefaultCacheOptions)
 		}
+		discovery.MonitorServiceConnectivity()
 		discovery.WithMasterAuthServers(viper.GetStringSlice("discovery.master-auth-servers")...)
 		err = discovery.Init(component)
 		if err != nil {

--- a/core/discovery/connectivity.go
+++ b/core/discovery/connectivity.go
@@ -1,0 +1,142 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package discovery
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/TheThingsNetwork/ttn/core/discovery/announcement"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials"
+)
+
+type serviceID struct {
+	serviceName string
+	id          string
+}
+
+type serviceStatus struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	*grpc.ClientConn
+
+	mu              sync.RWMutex
+	lastAnnounce    time.Time
+	lastStateChange time.Time
+	lastAvailable   time.Time
+}
+
+func (s *serviceStatus) Available() (available bool) {
+	s.mu.RLock()
+	available = !s.lastAvailable.Before(s.lastStateChange)
+	s.mu.RUnlock()
+	return
+}
+
+func (d *discovery) startConnectivityMonitor() {
+	go func() {
+		for {
+			if err := d.updateStatus(); err != nil {
+				d.Ctx.WithError(err).Warn("Could not update service status")
+			}
+			time.Sleep(time.Minute)
+		}
+	}()
+}
+
+func (d *discovery) filterAvailable(announcements []*announcement.Announcement) []*announcement.Announcement {
+	d.statusMu.RLock()
+	defer d.statusMu.RUnlock()
+	if d.serviceStatus == nil {
+		return announcements
+	}
+	filtered := make([]*announcement.Announcement, 0, len(announcements))
+	for _, a := range announcements {
+		if status, ok := d.serviceStatus[serviceID{a.ServiceName, a.ID}]; ok && status.Available() {
+			filtered = append(filtered, a)
+		}
+	}
+	return filtered
+}
+
+func (d *discovery) updateStatus() error {
+	d.statusMu.Lock()
+	defer d.statusMu.Unlock()
+	if d.serviceStatus == nil {
+		d.serviceStatus = make(map[serviceID]*serviceStatus)
+	}
+	announcements, err := d.services.List(nil)
+	if err != nil {
+		return err
+	}
+	now := time.Now()
+	for _, a := range announcements {
+		id := serviceID{a.ServiceName, a.ID}
+		status, ok := d.serviceStatus[id]
+		if !ok { // newly announced service
+			status = &serviceStatus{lastStateChange: now}
+			status.ctx, status.cancel = context.WithCancel(context.Background())
+			target := strings.Split(a.NetAddress, ",")[0]
+			if target != "" {
+				var tlsConfig *tls.Config
+				host, _, _ := net.SplitHostPort(target)
+				caPool := x509.NewCertPool()
+				if caPool.AppendCertsFromPEM([]byte(a.Certificate)) {
+					tlsConfig = &tls.Config{ServerName: host, RootCAs: caPool}
+				}
+				backoff := grpc.DefaultBackoffConfig
+				backoff.MaxDelay = 10 * time.Minute
+				status.ClientConn, err = grpc.Dial(target,
+					grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
+					grpc.WithBackoffConfig(backoff),
+				)
+				if err == nil {
+					go func() { // start monitoring
+						defer status.ClientConn.Close()
+						state := status.ClientConn.GetState()
+						for {
+							if status.ClientConn.WaitForStateChange(status.ctx, state) { // blocking
+								status.mu.Lock()
+								state = status.ClientConn.GetState()
+								status.lastStateChange = time.Now()
+								switch state {
+								case connectivity.Idle:
+								case connectivity.Connecting:
+								case connectivity.Ready:
+									d.Ctx.Infof("%s %s is available", id.serviceName, id.id)
+									status.lastAvailable = status.lastStateChange
+								case connectivity.TransientFailure:
+								case connectivity.Shutdown:
+								}
+								status.mu.Unlock()
+							} else { // context canceled
+								return
+							}
+						}
+					}()
+				}
+			}
+			d.serviceStatus[serviceID{a.ServiceName, a.ID}] = status
+		}
+		status.lastAnnounce = now
+	}
+
+	// stop monitoring old announcements
+	for id, status := range d.serviceStatus {
+		if status.lastAnnounce != now {
+			status.cancel()
+			delete(d.serviceStatus, id)
+		}
+	}
+
+	return nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1204,124 +1204,148 @@
 			"revisionTime": "2017-04-04T13:20:09Z"
 		},
 		{
-			"checksumSHA1": "C7tZiqE2ak3AW3IInhSAQ2YhajY=",
+			"checksumSHA1": "8ism6z4kloUguM+IYfHzwTVoI1o=",
 			"path": "google.golang.org/grpc",
-			"revision": "41d9b6ea2a6335f3a22074ed35c0542c9da1baf4",
-			"revisionTime": "2017-07-05T23:51:14Z"
+			"revision": "c1fc29613da668384b9a63e81b424d627f0b0a02",
+			"revisionTime": "2017-11-14T23:20:10Z"
 		},
 		{
-			"checksumSHA1": "AS14kO6FrzuQ/8wP+a/n55SNW6U=",
+			"checksumSHA1": "rbTWD4bqUpDwyuLPqzHwJZYlBbQ=",
 			"path": "google.golang.org/grpc/balancer",
-			"revision": "d4b75ebd4f9f8c4a2b1cdadbdbe0d7920431ccca",
-			"revisionTime": "2017-09-21T19:46:03Z"
+			"revision": "c1fc29613da668384b9a63e81b424d627f0b0a02",
+			"revisionTime": "2017-11-14T23:20:10Z"
 		},
 		{
-			"checksumSHA1": "/eTpFgjvMq5Bc9hYnw5fzKG4B6I=",
+			"checksumSHA1": "os98urLvZVriKRbHhIsipJfcT7Q=",
+			"path": "google.golang.org/grpc/balancer/roundrobin",
+			"revision": "c1fc29613da668384b9a63e81b424d627f0b0a02",
+			"revisionTime": "2017-11-14T23:20:10Z"
+		},
+		{
+			"checksumSHA1": "m5QNRsnKMZ/3p4V/LDLknFInkGs=",
 			"path": "google.golang.org/grpc/codes",
-			"revision": "41d9b6ea2a6335f3a22074ed35c0542c9da1baf4",
-			"revisionTime": "2017-07-05T23:51:14Z"
+			"revision": "c1fc29613da668384b9a63e81b424d627f0b0a02",
+			"revisionTime": "2017-11-14T23:20:10Z"
 		},
 		{
 			"checksumSHA1": "XH2WYcDNwVO47zYShREJjcYXm0Y=",
 			"path": "google.golang.org/grpc/connectivity",
-			"revision": "d4b75ebd4f9f8c4a2b1cdadbdbe0d7920431ccca",
-			"revisionTime": "2017-09-21T19:46:03Z"
+			"revision": "c1fc29613da668384b9a63e81b424d627f0b0a02",
+			"revisionTime": "2017-11-14T23:20:10Z"
 		},
 		{
-			"checksumSHA1": "5ylThBvJnIcyWhL17AC9+Sdbw2E=",
+			"checksumSHA1": "4DnDX81AOSyVP3UJ5tQmlNcG1MI=",
 			"path": "google.golang.org/grpc/credentials",
-			"revision": "41d9b6ea2a6335f3a22074ed35c0542c9da1baf4",
-			"revisionTime": "2017-07-05T23:51:14Z"
+			"revision": "c1fc29613da668384b9a63e81b424d627f0b0a02",
+			"revisionTime": "2017-11-14T23:20:10Z"
 		},
 		{
-			"checksumSHA1": "2NbY9kmMweE4VUsruRsvmViVnNg=",
+			"checksumSHA1": "k3l7Hrce7IiDOzDlF4UDJ4fs2Bc=",
+			"path": "google.golang.org/grpc/encoding",
+			"revision": "c1fc29613da668384b9a63e81b424d627f0b0a02",
+			"revisionTime": "2017-11-14T23:20:10Z"
+		},
+		{
+			"checksumSHA1": "XbDzI4GeUt2/8WAS5mLKm5ghVWo=",
 			"path": "google.golang.org/grpc/grpclb/grpc_lb_v1",
-			"revision": "41d9b6ea2a6335f3a22074ed35c0542c9da1baf4",
-			"revisionTime": "2017-07-05T23:51:14Z"
+			"revision": "c1fc29613da668384b9a63e81b424d627f0b0a02",
+			"revisionTime": "2017-11-14T23:20:10Z"
 		},
 		{
-			"checksumSHA1": "WxP3QV0Y4fIx5NsT0dwBp6JsrJE=",
+			"checksumSHA1": "H7SuPUqbPcdbNqgl+k3ohuwMAwE=",
 			"path": "google.golang.org/grpc/grpclb/grpc_lb_v1/messages",
-			"revision": "d4b75ebd4f9f8c4a2b1cdadbdbe0d7920431ccca",
-			"revisionTime": "2017-09-21T19:46:03Z"
+			"revision": "c1fc29613da668384b9a63e81b424d627f0b0a02",
+			"revisionTime": "2017-11-14T23:20:10Z"
 		},
 		{
-			"checksumSHA1": "+OUZtnh06yy+Y8YowXWs7p//Jb4=",
+			"checksumSHA1": "ntHev01vgZgeIh5VFRmbLx/BSTo=",
 			"path": "google.golang.org/grpc/grpclog",
-			"revision": "41d9b6ea2a6335f3a22074ed35c0542c9da1baf4",
-			"revisionTime": "2017-07-05T23:51:14Z"
+			"revision": "c1fc29613da668384b9a63e81b424d627f0b0a02",
+			"revisionTime": "2017-11-14T23:20:10Z"
 		},
 		{
-			"checksumSHA1": "pc9cweMiKQ5hVMuO9UoMGdbizaY=",
+			"checksumSHA1": "DyM0uqLtknaI4THSc3spn9XlL+g=",
 			"path": "google.golang.org/grpc/health",
-			"revision": "41d9b6ea2a6335f3a22074ed35c0542c9da1baf4",
-			"revisionTime": "2017-07-05T23:51:14Z"
+			"revision": "c1fc29613da668384b9a63e81b424d627f0b0a02",
+			"revisionTime": "2017-11-14T23:20:10Z"
 		},
 		{
-			"checksumSHA1": "W5KfI1NIGJt7JaVnLzefDZr3+4s=",
+			"checksumSHA1": "6vY7tYjV84pnr3sDctzx53Bs8b0=",
 			"path": "google.golang.org/grpc/health/grpc_health_v1",
-			"revision": "41d9b6ea2a6335f3a22074ed35c0542c9da1baf4",
-			"revisionTime": "2017-07-05T23:51:14Z"
+			"revision": "c1fc29613da668384b9a63e81b424d627f0b0a02",
+			"revisionTime": "2017-11-14T23:20:10Z"
 		},
 		{
-			"checksumSHA1": "U9vDe05/tQrvFBojOQX8Xk12W9I=",
+			"checksumSHA1": "Qvf3zdmRCSsiM/VoBv0qB/naHtU=",
 			"path": "google.golang.org/grpc/internal",
-			"revision": "41d9b6ea2a6335f3a22074ed35c0542c9da1baf4",
-			"revisionTime": "2017-07-05T23:51:14Z"
+			"revision": "c1fc29613da668384b9a63e81b424d627f0b0a02",
+			"revisionTime": "2017-11-14T23:20:10Z"
 		},
 		{
 			"checksumSHA1": "hcuHgKp8W0wIzoCnNfKI8NUss5o=",
 			"path": "google.golang.org/grpc/keepalive",
-			"revision": "41d9b6ea2a6335f3a22074ed35c0542c9da1baf4",
-			"revisionTime": "2017-07-05T23:51:14Z"
+			"revision": "c1fc29613da668384b9a63e81b424d627f0b0a02",
+			"revisionTime": "2017-11-14T23:20:10Z"
 		},
 		{
-			"checksumSHA1": "HH3h5npBG+wwoxWeyVjIpxnloxQ=",
+			"checksumSHA1": "KeUmTZV+2X46C49cKyjp+xM7fvw=",
 			"path": "google.golang.org/grpc/metadata",
-			"revision": "41d9b6ea2a6335f3a22074ed35c0542c9da1baf4",
-			"revisionTime": "2017-07-05T23:51:14Z"
+			"revision": "c1fc29613da668384b9a63e81b424d627f0b0a02",
+			"revisionTime": "2017-11-14T23:20:10Z"
 		},
 		{
-			"checksumSHA1": "Zzb7Xsc3tbTJzrcZbSPyye+yxmw=",
+			"checksumSHA1": "dgwdT20kXe4ZbXBOFbTwVQt8rmA=",
 			"path": "google.golang.org/grpc/naming",
-			"revision": "41d9b6ea2a6335f3a22074ed35c0542c9da1baf4",
-			"revisionTime": "2017-07-05T23:51:14Z"
+			"revision": "c1fc29613da668384b9a63e81b424d627f0b0a02",
+			"revisionTime": "2017-11-14T23:20:10Z"
 		},
 		{
 			"checksumSHA1": "n5EgDdBqFMa2KQFhtl+FF/4gIFo=",
 			"path": "google.golang.org/grpc/peer",
-			"revision": "41d9b6ea2a6335f3a22074ed35c0542c9da1baf4",
-			"revisionTime": "2017-07-05T23:51:14Z"
+			"revision": "c1fc29613da668384b9a63e81b424d627f0b0a02",
+			"revisionTime": "2017-11-14T23:20:10Z"
 		},
 		{
-			"checksumSHA1": "bJJaQUbZqEpTlnXTXgGwOZWijs4=",
+			"checksumSHA1": "H7VyP18nJ9MmoB5r9+I7EKVEeVM=",
 			"path": "google.golang.org/grpc/resolver",
-			"revision": "d4b75ebd4f9f8c4a2b1cdadbdbe0d7920431ccca",
-			"revisionTime": "2017-09-21T19:46:03Z"
+			"revision": "c1fc29613da668384b9a63e81b424d627f0b0a02",
+			"revisionTime": "2017-11-14T23:20:10Z"
 		},
 		{
-			"checksumSHA1": "ZY8Tq61fGK1stTuvwK5WoqcU8j8=",
+			"checksumSHA1": "WpWF+bDzObsHf+bjoGpb/abeFxo=",
+			"path": "google.golang.org/grpc/resolver/dns",
+			"revision": "c1fc29613da668384b9a63e81b424d627f0b0a02",
+			"revisionTime": "2017-11-14T23:20:10Z"
+		},
+		{
+			"checksumSHA1": "zs9M4xE8Lyg4wvuYvR00XoBxmuw=",
+			"path": "google.golang.org/grpc/resolver/passthrough",
+			"revision": "c1fc29613da668384b9a63e81b424d627f0b0a02",
+			"revisionTime": "2017-11-14T23:20:10Z"
+		},
+		{
+			"checksumSHA1": "G9lgXNi7qClo5sM2s6TbTHLFR3g=",
 			"path": "google.golang.org/grpc/stats",
-			"revision": "41d9b6ea2a6335f3a22074ed35c0542c9da1baf4",
-			"revisionTime": "2017-07-05T23:51:14Z"
+			"revision": "c1fc29613da668384b9a63e81b424d627f0b0a02",
+			"revisionTime": "2017-11-14T23:20:10Z"
 		},
 		{
-			"checksumSHA1": "DIv9qbApAoh2cF2G3Br24lVPqUI=",
+			"checksumSHA1": "3Dwz4RLstDHMPyDA7BUsYe+JP4w=",
 			"path": "google.golang.org/grpc/status",
-			"revision": "41d9b6ea2a6335f3a22074ed35c0542c9da1baf4",
-			"revisionTime": "2017-07-05T23:51:14Z"
+			"revision": "c1fc29613da668384b9a63e81b424d627f0b0a02",
+			"revisionTime": "2017-11-14T23:20:10Z"
 		},
 		{
-			"checksumSHA1": "aixGx/Kd0cj9ZlZHacpHe3XgMQ4=",
+			"checksumSHA1": "qvArRhlrww5WvRmbyMF2mUfbJew=",
 			"path": "google.golang.org/grpc/tap",
-			"revision": "41d9b6ea2a6335f3a22074ed35c0542c9da1baf4",
-			"revisionTime": "2017-07-05T23:51:14Z"
+			"revision": "c1fc29613da668384b9a63e81b424d627f0b0a02",
+			"revisionTime": "2017-11-14T23:20:10Z"
 		},
 		{
-			"checksumSHA1": "ERjj5Omhxd6TmhvqwG7Ok4Fvksc=",
+			"checksumSHA1": "UcwGrAVlXOjKhjwrlycA/93AiZs=",
 			"path": "google.golang.org/grpc/transport",
-			"revision": "41d9b6ea2a6335f3a22074ed35c0542c9da1baf4",
-			"revisionTime": "2017-07-05T23:51:14Z"
+			"revision": "c1fc29613da668384b9a63e81b424d627f0b0a02",
+			"revisionTime": "2017-11-14T23:20:10Z"
 		},
 		{
 			"checksumSHA1": "OU/wHTJqhyQfyRnXMVWx1Ox06kQ=",


### PR DESCRIPTION
This PR adds a filtering mechanism to the Discovery server. With this mechanism, unreachable routing services will not be returned when requesting services using the `GetAll` rpc. When services come back online, the will be returned again.