### PR TITLE
v2.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ When you get started with The Things Network, you'll probably have some question
 - Read the [official documentation](https://www.thethingsnetwork.org/docs/)
 - Register on the [forum](https://www.thethingsnetwork.org/forum/) and search around
 - Join [Slack](https://slack.thethingsnetwork.org) and ask us what you want to know
-- Read background information on the [wiki](https://www.thethingsnetwork.org/wiki/)
 
 ## Installing and Running The Things Network Stack
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -166,6 +166,8 @@ func init() {
 	RootCmd.PersistentFlags().Bool("allow-insecure", false, "Allow insecure fallback if TLS unavailable")
 	RootCmd.PersistentFlags().String("key-dir", path.Clean(dir+"/.ttn/"), "The directory where public/private keys are stored")
 
+	RootCmd.PersistentFlags().Int("eu-rx2-dr", 3, "RX2 data rate for the EU band (SF12=0,SF9=3)")
+
 	viper.BindPFlags(RootCmd.PersistentFlags())
 }
 

--- a/core/band/band.go
+++ b/core/band/band.go
@@ -118,6 +118,7 @@ func Get(region string) (frequencyPlan FrequencyPlan, err error) {
 		frequencyPlan.Band, err = lora.GetConfig(lora.CN_470_510, false, lorawan.DwellTimeNoLimit)
 	case pb_lorawan.FrequencyPlan_AS_923.String():
 		frequencyPlan.Band, err = lora.GetConfig(lora.AS_923, false, lorawan.DwellTime400ms)
+		frequencyPlan.ADR = &ADRConfig{MinDataRate: 0, MaxDataRate: 5, MinTXPower: 2, MaxTXPower: 14, StepTXPower: 2}
 	case pb_lorawan.FrequencyPlan_AS_920_923.String():
 		frequencyPlan.Band, err = lora.GetConfig(lora.AS_923, false, lorawan.DwellTime400ms)
 		frequencyPlan.UplinkChannels = []lora.Channel{
@@ -134,6 +135,7 @@ func Get(region string) (frequencyPlan FrequencyPlan, err error) {
 		}
 		frequencyPlan.DownlinkChannels = frequencyPlan.UplinkChannels
 		frequencyPlan.CFList = &lorawan.CFList{922200000, 922400000, 922600000, 922800000, 923000000}
+		frequencyPlan.ADR = &ADRConfig{MinDataRate: 0, MaxDataRate: 5, MinTXPower: 2, MaxTXPower: 14, StepTXPower: 2}
 	case pb_lorawan.FrequencyPlan_AS_923_925.String():
 		frequencyPlan.Band, err = lora.GetConfig(lora.AS_923, false, lorawan.DwellTime400ms)
 		frequencyPlan.UplinkChannels = []lora.Channel{
@@ -150,6 +152,7 @@ func Get(region string) (frequencyPlan FrequencyPlan, err error) {
 		}
 		frequencyPlan.DownlinkChannels = frequencyPlan.UplinkChannels
 		frequencyPlan.CFList = &lorawan.CFList{923600000, 923800000, 924000000, 924200000, 924400000}
+		frequencyPlan.ADR = &ADRConfig{MinDataRate: 0, MaxDataRate: 5, MinTXPower: 2, MaxTXPower: 14, StepTXPower: 2}
 	case pb_lorawan.FrequencyPlan_KR_920_923.String():
 		frequencyPlan.Band, err = lora.GetConfig(lora.KR_920_923, false, lorawan.DwellTimeNoLimit)
 		// TTN frequency plan includes extra channels next to the default channels:

--- a/core/band/band_test.go
+++ b/core/band/band_test.go
@@ -76,21 +76,21 @@ func TestGet(t *testing.T) {
 		fp, err := Get("AS_923")
 		a.So(err, ShouldBeNil)
 		a.So(fp.CFList, ShouldBeNil)
-		a.So(fp.ADR, ShouldBeNil)
+		a.So(fp.ADR, ShouldNotBeNil)
 	}
 
 	{
 		fp, err := Get("AS_920_923")
 		a.So(err, ShouldBeNil)
 		a.So(fp.CFList, ShouldNotBeNil)
-		a.So(fp.ADR, ShouldBeNil)
+		a.So(fp.ADR, ShouldNotBeNil)
 	}
 
 	{
 		fp, err := Get("AS_923_925")
 		a.So(err, ShouldBeNil)
 		a.So(fp.CFList, ShouldNotBeNil)
-		a.So(fp.ADR, ShouldBeNil)
+		a.So(fp.ADR, ShouldNotBeNil)
 	}
 
 	{

--- a/core/discovery/server.go
+++ b/core/discovery/server.go
@@ -181,6 +181,7 @@ func (d *discoveryServer) GetByAppID(ctx context.Context, req *pb.GetByAppIDRequ
 	if err != nil {
 		return nil, err
 	}
+	service.Metadata = nil
 	return service, nil
 }
 
@@ -189,6 +190,7 @@ func (d *discoveryServer) GetByGatewayID(ctx context.Context, req *pb.GetByGatew
 	if err != nil {
 		return nil, err
 	}
+	service.Metadata = nil
 	return service, nil
 }
 
@@ -200,6 +202,7 @@ func (d *discoveryServer) GetByAppEUI(ctx context.Context, req *pb.GetByAppEUIRe
 	if err != nil {
 		return nil, err
 	}
+	service.Metadata = nil
 	return service, nil
 }
 

--- a/core/router/downlink_test.go
+++ b/core/router/downlink_test.go
@@ -20,8 +20,13 @@ import (
 	. "github.com/TheThingsNetwork/ttn/utils/testing"
 	"github.com/golang/mock/gomock"
 	. "github.com/smartystreets/assertions"
+	"github.com/spf13/viper"
 	"golang.org/x/net/context"
 )
+
+func init() {
+	viper.Set("eu-rx2-dr", "3")
+}
 
 // newReferenceDownlink returns a default uplink message
 func newReferenceDownlink() *pb.DownlinkMessage {

--- a/core/storage/redis_store.go
+++ b/core/storage/redis_store.go
@@ -37,7 +37,7 @@ func (s *RedisStore) Keys(selector string) ([]string, error) {
 	var allKeys []string
 	var cursor uint64
 	for {
-		keys, next, err := s.client.Scan(cursor, selector, 0).Result()
+		keys, next, err := s.client.Scan(cursor, selector, 10000).Result()
 		if err != nil {
 			return nil, err
 		}

--- a/mqtt/README.md
+++ b/mqtt/README.md
@@ -1,9 +1,8 @@
 # API Reference
 
 * Host: `<Region>.thethings.network`, where `<Region>` is last part of the handler you registered your application to, e.g. `eu`.
-* Port: `1883` or `8883` for TLS
-* PEM encoded CA certificate for TLS: [mqtt-ca.pem](https://console.thethingsnetwork.org/mqtt-ca.pem)
-  - Note: When this certificate expires, we will migrate to Let's Encrypt certificates. Therefore you might want to include the [Let's Encrypt Roots](https://letsencrypt.org/certificates/) in your certificate chain.
+* Port: `1883`, or `8883` for TLS
+* For TLS, the server uses a Let's Encrypt certificate. If your server does not trust that yet, you might want to include the [Let's Encrypt Roots](https://letsencrypt.org/certificates/) in your certificate chain. Alternatively you can use our PEM-encoded CA certificate, which includes those roots as well: [mqtt-ca.pem](https://console.thethingsnetwork.org/mqtt-ca.pem)
 * Username: Application ID
 * Password: Application Access Key
 

--- a/ttnctl/cmd/clients_request.go
+++ b/ttnctl/cmd/clients_request.go
@@ -4,6 +4,8 @@
 package cmd
 
 import (
+	"net/http"
+
 	accountlib "github.com/TheThingsNetwork/go-account-lib/account"
 	"github.com/TheThingsNetwork/ttn/ttnctl/util"
 	"github.com/spf13/cobra"
@@ -22,11 +24,28 @@ var clientRequestCmd = &cobra.Command{
 		var name = args[0]
 		var description = args[1]
 
-		ctx = ctx.WithField("OAuthClientName", name)
-
 		uri, err := cmd.Flags().GetString("uri")
 		if err != nil {
 			ctx.WithError(err).Fatal("Error with URI")
+		}
+
+		var uriOK bool
+		ctx.Info("Testing Callback URI: " + uri + "?code=test&state=test")
+		res, err := http.Get(uri + "?code=test&state=test")
+		switch {
+		case err != nil:
+			ctx.WithError(err).Error("Callback URI test failed.")
+		case res.StatusCode == 404:
+			ctx.Error("Callback URI was not found (404)")
+		case res.StatusCode >= 500:
+			ctx.Errorf("Callback URI errored (%d)", res.StatusCode)
+		default:
+			ctx.Infof("Callback URI seems to be reachable (returned %d)", res.StatusCode)
+			uriOK = true
+		}
+		if !uriOK && !confirm("Are you sure the URI is correct? (y/N)") {
+			ctx.Info("Aborting")
+			return
 		}
 
 		scopes := make([]string, 0)

--- a/ttnctl/cmd/clients_request.go
+++ b/ttnctl/cmd/clients_request.go
@@ -14,7 +14,20 @@ import (
 var clientRequestCmd = &cobra.Command{
 	Use:   "request [Name] [Description]",
 	Short: "Request a client",
-	Long:  "ttnctl clients request can be used to request an OAuth client from the network staff.",
+	Long: `ttnctl clients request can be used to request an OAuth client from the network staff.
+	You need to supply the following information:
+	- An identifier for your OAuth client; can contain lowercase letters, numbers, dashes and underscores, just like Application and Gateway IDs.
+	- A description that will be shown to users that are signing in.
+	- A callback URI where users will be redirected after login.
+	- The scopes that your client needs access to:
+		- apps: Create and delete Applications
+		- gateways: Create and delete Gateways
+		- profile: Edit user profiles
+		- Note that you may not need an OAuth client to manage devices.
+	- The grants that your client uses for login:
+		- authorization_code: OAuth 2.0 authorization code (this is probably what you need)
+		- refresh_token: OAuth 2.0 refresh token grant
+		- password: OAuth 2.0 password grant (this will usually not be accepted)`,
 	Example: `$ ttnctl clients request my-gateway-editor "Client used to consult and edit gateway information" --uri "https://mygatewayclient.org/oauth/callback" --scope "profile,gateways" --grants "authorization_code,refresh_token"
   INFO OAuth client requested OAuthClientName=my-gateway-editor
 `,

--- a/ttnctl/cmd/gateways_list.go
+++ b/ttnctl/cmd/gateways_list.go
@@ -41,7 +41,7 @@ var gatewaysListCmd = &cobra.Command{
 				lng = gateway.AntennaLocation.Longitude
 				alt = gateway.AntennaLocation.Altitude
 			}
-			table.AddRow(i+1, gateway.ID, gateway.Activated, gateway.FrequencyPlan, fmt.Sprintf("(%f, %f, %f)", lat, lng, alt))
+			table.AddRow(i+1, gateway.ID, gateway.Activated, gateway.FrequencyPlan, fmt.Sprintf("(%f, %f, %d)", lat, lng, alt))
 		}
 
 		fmt.Println()


### PR DESCRIPTION
The v2.9.2 release contains some minor improvements:

- The RX2 data rate for the EU channel plan is now configurable on a network-level (TTN's public community network uses DR3/SF9BW128 for RX2)
- Added ADR configurations for AS923-based channel plans
- Optimized some Discovery RPCs
- Optimized Redis range scans
- Improved `ttnctl`'s OAuth2 client request command
- Fix `ttnctl`'s formatting of the gateway list