### PR TITLE
Fix ADR for AU915 band

### DIFF
--- a/core/band/band.go
+++ b/core/band/band.go
@@ -113,7 +113,7 @@ func Get(region string) (frequencyPlan FrequencyPlan, err error) {
 				frequencyPlan.DisableUplinkChannel(channel)
 			}
 		}
-		frequencyPlan.ADR = &ADRConfig{MinDataRate: 0, MaxDataRate: 3, MinTXPower: 10, MaxTXPower: 20, StepTXPower: 2}
+		frequencyPlan.ADR = &ADRConfig{MinDataRate: 0, MaxDataRate: 5, MinTXPower: 10, MaxTXPower: 20, StepTXPower: 2}
 	case pb_lorawan.FrequencyPlan_CN_470_510.String():
 		frequencyPlan.Band, err = lora.GetConfig(lora.CN_470_510, false, lorawan.DwellTimeNoLimit)
 	case pb_lorawan.FrequencyPlan_AS_923.String():

--- a/core/networkserver/adr.go
+++ b/core/networkserver/adr.go
@@ -307,11 +307,21 @@ func getAdrReqPayloads(dev *device.Device, frequencyPlan *band.FrequencyPlan, dr
 			}
 		}
 	case pb_lorawan.FrequencyPlan_US_902_928.String(), pb_lorawan.FrequencyPlan_AU_915_928.String():
+		var dr500 uint8
+		switch dev.ADR.Band {
+		case pb_lorawan.FrequencyPlan_US_902_928.String():
+			dr500 = 4
+		case pb_lorawan.FrequencyPlan_AU_915_928.String():
+			dr500 = 6
+		default:
+			panic("could not determine 500kHz channel data rate index")
+		}
+
 		// Adapted from https://github.com/brocaar/lorawan/blob/master/band/band_us902_928.go
 		payloads = []lorawan.LinkADRReqPayload{
 			{
-				DataRate: 4, // fixed settings for 500kHz channel
-				TXPower:  0, // fixed settings for 500kHz channel
+				DataRate: dr500, // fixed settings for 500kHz channel
+				TXPower:  0,     // fixed settings for 500kHz channel
 				Redundancy: lorawan.Redundancy{
 					ChMaskCntl: 7,
 					NbRep:      uint8(dev.ADR.NbTrans),

--- a/core/networkserver/adr_test.go
+++ b/core/networkserver/adr_test.go
@@ -255,7 +255,7 @@ func TestHandleDownlinkADR(t *testing.T) {
 		a.So(fOpts[1].CID, ShouldEqual, lorawan.LinkADRReq)
 		payload := new(lorawan.LinkADRReqPayload)
 		payload.UnmarshalBinary(fOpts[1].Payload) // First LinkAdrReq
-		a.So(payload.DataRate, ShouldEqual, 4)    // 500kHz channel, so DR4
+		a.So(payload.DataRate, ShouldEqual, 6)    // 500kHz channel, so DR6
 		a.So(payload.TXPower, ShouldEqual, 0)     // Max tx power
 		a.So(payload.Redundancy.ChMaskCntl, ShouldEqual, 7)
 		// Ch 64-71, All 125 kHz channels off


### PR DESCRIPTION
This PR fixes the ADR configuration for the ADR band, which was wrongly copy-pasted from the US configuration. The AU915 band has extra data rates, so instead of only DR0-3 we can optimize between DR0-5 in US915. This also means the 500kHz channel for the first req in the block should use DR6 instead of DR4.