### PR TITLE
Expose application and device count to Prometheus

### DIFF
--- a/core/handler/application/metrics.go
+++ b/core/handler/application/metrics.go
@@ -1,0 +1,35 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package application
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var applicationCount = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+	Namespace: "ttn",
+	Subsystem: "handler",
+	Name:      "registered_applications",
+	Help:      "Registered applications.",
+}, func() float64 {
+	var count uint64
+	for _, store := range stores {
+		applications, err := store.Count()
+		if err != nil {
+			continue
+		}
+		count += uint64(applications)
+	}
+	return float64(count)
+})
+
+func init() {
+	prometheus.Register(applicationCount)
+}
+
+var stores []*RedisApplicationStore
+
+func countStore(store *RedisApplicationStore) {
+	stores = append(stores, store)
+}

--- a/core/handler/application/store.go
+++ b/core/handler/application/store.go
@@ -35,9 +35,11 @@ func NewRedisApplicationStore(client *redis.Client, prefix string) Store {
 	for v, f := range migrate.ApplicationMigrations(prefix) {
 		store.AddMigration(v, f)
 	}
-	return &RedisApplicationStore{
+	s := &RedisApplicationStore{
 		store: store,
 	}
+	countStore(s)
+	return s
 }
 
 // RedisApplicationStore stores Applications in Redis.

--- a/core/handler/device/metrics.go
+++ b/core/handler/device/metrics.go
@@ -1,0 +1,35 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package device
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var deviceCount = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+	Namespace: "ttn",
+	Subsystem: "handler",
+	Name:      "registered_devices",
+	Help:      "Registered devices.",
+}, func() float64 {
+	var count uint64
+	for _, store := range stores {
+		devices, err := store.Count()
+		if err != nil {
+			continue
+		}
+		count += uint64(devices)
+	}
+	return float64(count)
+})
+
+func init() {
+	prometheus.Register(deviceCount)
+}
+
+var stores []*RedisDeviceStore
+
+func countStore(store *RedisDeviceStore) {
+	stores = append(stores, store)
+}

--- a/core/handler/device/store.go
+++ b/core/handler/device/store.go
@@ -61,6 +61,7 @@ func NewRedisDeviceStore(client *redis.Client, prefix string) *RedisDeviceStore 
 		queues: queues,
 	}
 	s.AddBuiltinAttribute(defaultDeviceAttributes...)
+	countStore(s)
 	return s
 }
 

--- a/core/networkserver/device/metrics.go
+++ b/core/networkserver/device/metrics.go
@@ -1,0 +1,35 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package device
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var deviceCount = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+	Namespace: "ttn",
+	Subsystem: "networkserver",
+	Name:      "registered_devices",
+	Help:      "Registered devices.",
+}, func() float64 {
+	var count uint64
+	for _, store := range stores {
+		devices, err := store.Count()
+		if err != nil {
+			continue
+		}
+		count += uint64(devices)
+	}
+	return float64(count)
+})
+
+func init() {
+	prometheus.Register(deviceCount)
+}
+
+var stores []*RedisDeviceStore
+
+func countStore(store *RedisDeviceStore) {
+	stores = append(stores, store)
+}

--- a/core/networkserver/device/store.go
+++ b/core/networkserver/device/store.go
@@ -43,13 +43,15 @@ func NewRedisDeviceStore(client *redis.Client, prefix string) Store {
 		store.AddMigration(v, f)
 	}
 	frameStore := storage.NewRedisQueueStore(client, prefix+":"+redisFramesPrefix)
-	return &RedisDeviceStore{
+	s := &RedisDeviceStore{
 		client:       client,
 		prefix:       prefix,
 		store:        store,
 		frameStore:   frameStore,
 		devAddrIndex: storage.NewRedisSetStore(client, prefix+":"+redisDevAddrPrefix),
 	}
+	countStore(s)
+	return s
 }
 
 // RedisDeviceStore stores Devices in Redis.


### PR DESCRIPTION
I left the copyright header on 2017 to avoid CI complaints, let's update those in a different PR.

One annoying thing is that the metric is registered in other components (router, broker), as the CLI imports all packages. There isn't anything we can do about that, I'm afraid. This will be better in v3 :)