### PR TITLE
Add updated data to device events.

### DIFF
--- a/core/handler/manager_server.go
+++ b/core/handler/manager_server.go
@@ -225,10 +225,29 @@ func (h *handlerManager) SetDevice(ctx context.Context, in *pb_handler.Device) (
 		AppID: dev.AppID,
 		DevID: dev.DevID,
 		Event: eventType,
-		Data:  nil, // Don't send potentially sensitive details over MQTT
+		Data:  eventUpdatedFields(dev),
 	}
 
 	return &gogo.Empty{}, nil
+}
+
+// eventUpdatedFields create DeviceEvent based of on the changelist of a device
+func eventUpdatedFields(dev *device.Device) types.DeviceEventData {
+	changeList := dev.ChangedFields()
+	e := types.DeviceEventData{}
+	for _, key := range changeList {
+		switch key {
+		case "Latitude":
+			e.Latitude = dev.Latitude
+		case "Longitude":
+			e.Longitude = dev.Longitude
+		case "Altitude":
+			e.Altitude = dev.Altitude
+		case "UpdatedAt":
+			e.UpdatedAt = dev.UpdatedAt
+		}
+	}
+	return e
 }
 
 func (h *handlerManager) DeleteDevice(ctx context.Context, in *pb_handler.DeviceIdentifier) (*gogo.Empty, error) {

--- a/core/handler/manager_server_test.go
+++ b/core/handler/manager_server_test.go
@@ -1,0 +1,43 @@
+package handler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/TheThingsNetwork/ttn/core/handler/device"
+	. "github.com/smartystreets/assertions"
+)
+
+func TestEventUpdatedFields(t *testing.T) {
+	a := New(t)
+
+	dev := &device.Device{
+		AppID:     "test",
+		DevID:     "test-dev",
+		Latitude:  0.0,
+		Longitude: 30.0,
+		Altitude:  100,
+		UpdatedAt: time.Now().Add(-time.Hour),
+		UsedAppNonces: []device.AppNonce{
+			[3]byte{00, 00, 01},
+		},
+		UsedDevNonces: []device.DevNonce{
+			[2]byte{01, 00},
+		},
+		Attributes: map[string]string{
+			"type": "testing",
+		},
+	}
+	dev.StartUpdate()
+	dev.Latitude = 10
+	dev.Longitude = 35
+	dev.Altitude = 25
+	dev.UsedAppNonces = append(dev.UsedAppNonces, device.AppNonce{00, 00, 02})
+	dev.UsedDevNonces = append(dev.UsedDevNonces, device.DevNonce{00, 02})
+	dev.UpdatedAt = time.Now()
+	eventUpdateData := eventUpdatedFields(dev)
+	a.So(eventUpdateData.UpdatedAt.Equal(dev.UpdatedAt), ShouldBeTrue)
+	a.So(eventUpdateData.Altitude, ShouldEqual, dev.Altitude)
+	a.So(eventUpdateData.Longitude, ShouldEqual, dev.Longitude)
+	a.So(eventUpdateData.Latitude, ShouldEqual, dev.Latitude)
+}

--- a/core/types/event.go
+++ b/core/types/event.go
@@ -81,3 +81,12 @@ type DownlinkEventData struct {
 	GatewayID string                   `json:"gateway_id,omitempty"`
 	Config    *DownlinkEventConfigInfo `json:"config,omitempty"`
 }
+
+// DeviceEventData contains the updated of a set/updated device
+type DeviceEventData struct {
+	Latitude   float32           `json:"latitude,omitempty"`
+	Longitude  float32           `json:"longitude,omitempty"`
+	Altitude   int32             `json:"altitude,omitempty"`
+	Attributes map[string]string `json:"attributes,omitempty"`
+	UpdatedAt  time.Time         `json:"update_at,omitempty"`
+}


### PR DESCRIPTION
Add location and UpdateAt to device event data, if updated, when device a registry change.

Refer #713 