### PR TITLE
Add RU_864_870 frequency plan to support LoRaWAN in Russia

### DIFF
--- a/core/band/band.go
+++ b/core/band/band.go
@@ -169,6 +169,22 @@ func Get(region string) (frequencyPlan FrequencyPlan, err error) {
 		frequencyPlan.CFList = &lorawan.CFList{922700000, 922900000, 923100000, 923300000, 0}
 	case pb_lorawan.FrequencyPlan_IN_865_867.String():
 		frequencyPlan.Band, err = lora.GetConfig(lora.IN_865_867, false, lorawan.DwellTimeNoLimit)
+	case pb_lorawan.FrequencyPlan_RU_864_870.String():
+		frequencyPlan.Band, err = lora.GetConfig(lora.RU_864_870, false, lorawan.DwellTimeNoLimit)
+		// Here channels from recommended list for Russia are set which are used by LoRaWAN networks in Russia
+		// Recommended frequency plan includes extra channels next to the default channels:
+		frequencyPlan.UplinkChannels = []lora.Channel{
+			lora.Channel{Frequency: 868900000, DataRates: []int{0, 1, 2, 3, 4, 5}},
+			lora.Channel{Frequency: 869100000, DataRates: []int{0, 1, 2, 3, 4, 5}},
+			lora.Channel{Frequency: 864100000, DataRates: []int{0, 1, 2, 3, 4, 5}},
+			lora.Channel{Frequency: 864300000, DataRates: []int{0, 1, 2, 3, 4, 5}},
+			lora.Channel{Frequency: 864500000, DataRates: []int{0, 1, 2, 3, 4, 5}},
+			lora.Channel{Frequency: 864700000, DataRates: []int{0, 1, 2, 3, 4, 5}},
+			lora.Channel{Frequency: 864900000, DataRates: []int{0, 1, 2, 3, 4, 5}},
+		}
+		frequencyPlan.DownlinkChannels = frequencyPlan.UplinkChannels
+		frequencyPlan.CFList = &lorawan.CFList{864100000, 864300000, 864500000, 864700000, 864900000}
+		frequencyPlan.ADR = &ADRConfig{MinDataRate: 0, MaxDataRate: 5, MinTXPower: 2, MaxTXPower: 14, StepTXPower: 3}
 	default:
 		err = errors.NewErrInvalidArgument("Frequency Band", "unknown")
 	}
@@ -193,6 +209,7 @@ func init() {
 		pb_lorawan.FrequencyPlan_KR_920_923,
 		pb_lorawan.FrequencyPlan_AU_915_928,
 		pb_lorawan.FrequencyPlan_CN_470_510,
+		pb_lorawan.FrequencyPlan_RU_864_870,
 	} {
 		region := r.String()
 		frequencyPlans[region], _ = Get(region)

--- a/core/band/band_test.go
+++ b/core/band/band_test.go
@@ -23,6 +23,7 @@ func TestGuess(t *testing.T) {
 	a.So(Guess(923600000), ShouldEqual, "AS_923_925")
 	a.So(Guess(922100000), ShouldEqual, "KR_920_923")
 	a.So(Guess(865062500), ShouldEqual, "IN_865_867")
+	a.So(Guess(868900000), ShouldEqual, "RU_864_870")
 
 	a.So(Guess(922100001), ShouldEqual, "") // Not allowed
 }
@@ -105,6 +106,13 @@ func TestGet(t *testing.T) {
 		a.So(err, ShouldBeNil)
 		a.So(fp.CFList, ShouldBeNil)
 		a.So(fp.ADR, ShouldBeNil)
+	}
+
+	{
+		fp, err := Get("RU_864_870")
+		a.So(err, ShouldBeNil)
+		a.So(fp.CFList, ShouldNotBeNil)
+		a.So(fp.ADR, ShouldNotBeNil)
 	}
 
 }

--- a/vendor/github.com/brocaar/lorawan/band/band.go
+++ b/vendor/github.com/brocaar/lorawan/band/band.go
@@ -24,7 +24,7 @@ const (
 	EU_863_870 Name = "EU_863_870"
 	IN_865_867 Name = "IN_865_867"
 	KR_920_923 Name = "KR_920_923"
-	RU_864_869 Name = "RU_864_869"
+	RU_864_870 Name = "RU_864_870"
 	US_902_928 Name = "US_902_928"
 )
 
@@ -468,7 +468,7 @@ func GetConfig(name Name, repeaterCompatible bool, dt lorawan.DwellTime) (Band, 
 		return newIN865Band(repeaterCompatible)
 	case KR_920_923:
 		return newKR920Band()
-	case RU_864_869:
+	case RU_864_870:
 		return newRU864Band(repeaterCompatible)
 	case US_902_928:
 		return newUS902Band(repeaterCompatible)

--- a/vendor/github.com/brocaar/lorawan/band/band_ru864_870.go
+++ b/vendor/github.com/brocaar/lorawan/band/band_ru864_870.go
@@ -32,7 +32,7 @@ func newRU864Band(repeaterCompatible bool) (Band, error) {
 	return Band{
 		DefaultTXPower:   14,
 		ImplementsCFlist: true,
-		RX2Frequency:     869050000,
+		RX2Frequency:     869100000,
 		RX2DataRate:      0,
 
 		MaxFCntGap:       16384,
@@ -79,15 +79,13 @@ func newRU864Band(repeaterCompatible bool) (Band, error) {
 		},
 
 		UplinkChannels: []Channel{
-			{Frequency: 864500000, DataRates: []int{0, 1, 2, 3, 4, 5}},
-			{Frequency: 864700000, DataRates: []int{0, 1, 2, 3, 4, 5}},
-			{Frequency: 864900000, DataRates: []int{0, 1, 2, 3, 4, 5}},
+			{Frequency: 868900000, DataRates: []int{0, 1, 2, 3, 4, 5}},
+			{Frequency: 869100000, DataRates: []int{0, 1, 2, 3, 4, 5}},
 		},
 
 		DownlinkChannels: []Channel{
-			{Frequency: 864500000, DataRates: []int{0, 1, 2, 3, 4, 5}},
-			{Frequency: 864700000, DataRates: []int{0, 1, 2, 3, 4, 5}},
-			{Frequency: 864900000, DataRates: []int{0, 1, 2, 3, 4, 5}},
+			{Frequency: 868900000, DataRates: []int{0, 1, 2, 3, 4, 5}},
+			{Frequency: 869100000, DataRates: []int{0, 1, 2, 3, 4, 5}},
 		},
 
 		getRX1ChannelFunc: func(txChannel int) int {


### PR DESCRIPTION
This pull request adds support for RU_864_870 frequency plan to support LoRaWAN in Russia. It includes a fix to brocaar library which was included into TTN code before the valid RU_864_870 was implemented in it and also updates version of api/protocol/lorawan dependency to the new one which has RU_864_870 in the list.
