### PR TITLE
Make US and AU FSB configurable

### DIFF
--- a/cmd/docs/README.md
+++ b/cmd/docs/README.md
@@ -6,6 +6,7 @@ The Things Network's backend servers.
 
 ```
       --allow-insecure                  Allow insecure fallback if TLS unavailable
+      --au-fsb int                      Frequency sub-band for the AU band (0-indexed) (default 1)
       --auth-token string               The JWT token to be used for the discovery server
       --config string                   config file (default "$HOME/.ttn.yml")
       --description string              The description of this component
@@ -23,6 +24,7 @@ The Things Network's backend servers.
       --no-cli-logs                     Disable CLI logs
       --public                          Announce this component as part of The Things Network (public community network)
       --tls                             Use TLS (default true)
+      --us-fsb int                      Frequency sub-band for the US band (0-indexed) (default 1)
 ```
 
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ import (
 	"github.com/TheThingsNetwork/go-utils/log/grpc"
 	promlog "github.com/TheThingsNetwork/go-utils/log/prometheus"
 	"github.com/TheThingsNetwork/ttn/api"
+	"github.com/TheThingsNetwork/ttn/core/band"
 	esHandler "github.com/TheThingsNetwork/ttn/utils/elasticsearch/handler"
 	"github.com/apex/log"
 	jsonHandler "github.com/apex/log/handlers/json"
@@ -110,6 +111,8 @@ var RootCmd = &cobra.Command{
 			"Auth Servers":             viper.GetStringMapString("auth-servers"),
 			"Monitors":                 viper.GetStringMapString("monitor-servers"),
 		}).Info("Initializing The Things Network")
+
+		band.InitializeTables()
 	},
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
 		if logFile != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -169,6 +169,8 @@ func init() {
 	RootCmd.PersistentFlags().String("key-dir", path.Clean(dir+"/.ttn/"), "The directory where public/private keys are stored")
 
 	RootCmd.PersistentFlags().Int("eu-rx2-dr", 3, "RX2 data rate for the EU band (SF12=0,SF9=3)")
+	RootCmd.PersistentFlags().Int("us-fsb", 1, "Frequency sub-band for the US band (0-indexed)")
+	RootCmd.PersistentFlags().Int("au-fsb", 1, "Frequency sub-band for the AU band (0-indexed)")
 
 	viper.BindPFlags(RootCmd.PersistentFlags())
 }

--- a/core/band/band.go
+++ b/core/band/band.go
@@ -64,6 +64,12 @@ func Guess(frequency uint64) string {
 	return ""
 }
 
+func init() {
+	viper.SetDefault("eu-rx2-dr", "3")
+	viper.SetDefault("us-fsb", "1")
+	viper.SetDefault("au-fsb", "1")
+}
+
 // Get the frequency plan for the given region
 func Get(region string) (frequencyPlan FrequencyPlan, err error) {
 	defer func() {
@@ -94,7 +100,7 @@ func Get(region string) (frequencyPlan FrequencyPlan, err error) {
 		frequencyPlan.ADR = &ADRConfig{MinDataRate: 0, MaxDataRate: 5, MinTXPower: 2, MaxTXPower: 14, StepTXPower: 3}
 	case pb_lorawan.FrequencyPlan_US_902_928.String():
 		frequencyPlan.Band, err = lora.GetConfig(lora.US_902_928, false, lorawan.DwellTime400ms)
-		fsb := 1 // Enable 903.9-905.3/200 kHz, 904.6/500kHz channels
+		fsb := viper.GetInt("us-fsb") // If this is 1, enables 903.9-905.3/200 kHz, 904.6/500kHz channels, etc.
 		for channel := 0; channel < 72; channel++ {
 			if (channel < fsb*8 || channel >= (fsb+1)*8) && channel != fsb+64 {
 				frequencyPlan.DisableUplinkChannel(channel)
@@ -107,7 +113,7 @@ func Get(region string) (frequencyPlan FrequencyPlan, err error) {
 		frequencyPlan.Band, err = lora.GetConfig(lora.EU_433, false, lorawan.DwellTimeNoLimit)
 	case pb_lorawan.FrequencyPlan_AU_915_928.String():
 		frequencyPlan.Band, err = lora.GetConfig(lora.AU_915_928, false, lorawan.DwellTime400ms)
-		fsb := 1 // Enable 916.8-918.2/200 kHz, 917.5/500kHz channels
+		fsb := viper.GetInt("au-fsb") // If this is 1, enables 916.8-918.2/200 kHz, 917.5/500kHz channels, etc.
 		for channel := 0; channel < 72; channel++ {
 			if (channel < fsb*8 || channel >= (fsb+1)*8) && channel != fsb+64 {
 				frequencyPlan.DisableUplinkChannel(channel)

--- a/core/band/band_test.go
+++ b/core/band/band_test.go
@@ -12,6 +12,8 @@ import (
 func TestGuess(t *testing.T) {
 	a := New(t)
 
+	InitializeTables()
+
 	a.So(Guess(868100000), ShouldEqual, "EU_863_870")
 	a.So(Guess(903900000), ShouldEqual, "US_902_928")
 	a.So(Guess(779500000), ShouldEqual, "CN_779_787")

--- a/core/router/downlink_test.go
+++ b/core/router/downlink_test.go
@@ -20,13 +20,8 @@ import (
 	. "github.com/TheThingsNetwork/ttn/utils/testing"
 	"github.com/golang/mock/gomock"
 	. "github.com/smartystreets/assertions"
-	"github.com/spf13/viper"
 	"golang.org/x/net/context"
 )
-
-func init() {
-	viper.Set("eu-rx2-dr", "3")
-}
 
 // newReferenceDownlink returns a default uplink message
 func newReferenceDownlink() *pb.DownlinkMessage {


### PR DESCRIPTION
This PR resolves #753 in a similar way as #692 did for the RX2 Data Rate in the EU band. We introduce new flags `us-fsb` and `au-fsb` which default to 1 (the old hardcoded value), but can be changed by the network operator if required.