### PR TITLE
Do not fall back to SF12 when activated using OTAA

### DIFF
--- a/core/networkserver/activation.go
+++ b/core/networkserver/activation.go
@@ -134,6 +134,7 @@ func (n *networkServer) HandleActivate(activation *pb_handler.DeviceActivationRe
 
 	dev.LastSeen = time.Now()
 	dev.UpdatedAt = time.Now()
+	dev.ActivatedAt = time.Now()
 	dev.DevAddr = *lorawan.DevAddr
 	dev.NwkSKey = *lorawan.NwkSKey
 	dev.FCntUp = 0

--- a/core/networkserver/device/device.go
+++ b/core/networkserver/device/device.go
@@ -36,9 +36,9 @@ type Device struct {
 	Options  Options       `redis:"options"`
 	ADR      ADRSettings   `redis:"adr,include"`
 
-	CreatedAt time.Time    `redis:"created_at"`
-	UpdatedAt time.Time    `redis:"updated_at"`
-	ActivatedAt time.Time  `redis:"activated_at"` // Indicates whether the device was activated via OTAA method
+	CreatedAt   time.Time `redis:"created_at"`
+	UpdatedAt   time.Time `redis:"updated_at"`
+	ActivatedAt time.Time `redis:"activated_at"` // Indicates whether the device was activated via OTAA method
 }
 
 // ADRSettings contains the (desired) settings for a device that uses ADR

--- a/core/networkserver/device/device.go
+++ b/core/networkserver/device/device.go
@@ -36,8 +36,9 @@ type Device struct {
 	Options  Options       `redis:"options"`
 	ADR      ADRSettings   `redis:"adr,include"`
 
-	CreatedAt time.Time `redis:"created_at"`
-	UpdatedAt time.Time `redis:"updated_at"`
+	CreatedAt time.Time    `redis:"created_at"`
+	UpdatedAt time.Time    `redis:"updated_at"`
+	ActivatedAt time.Time  `redis:"activated_at"` // Indicates whether the device was activated via OTAA method
 }
 
 // ADRSettings contains the (desired) settings for a device that uses ADR

--- a/core/networkserver/uplink_mac.go
+++ b/core/networkserver/uplink_mac.go
@@ -97,7 +97,7 @@ func (n *networkServer) handleUplinkMAC(message *pb_broker.DeduplicatedUplinkMes
 	}
 
 	// We did not receive an ADR response, the device may have the wrong RX2 settings
-	if dev.ADR.ExpectRes && dev.ADR.Band == "EU_863_870" && viper.GetInt("eu-rx2-dr") != 0 {
+	if dev.ADR.ExpectRes && dev.ADR.Band == "EU_863_870" && viper.GetInt("eu-rx2-dr") != 0 && dev.ActivatedAt.IsZero() {
 		settings := message.GetResponseTemplate().GetDownlinkOption()
 		if settings.GetGatewayConfiguration().Frequency == 869525000 {
 			if loraSettings := settings.ProtocolConfiguration.GetLoRaWAN(); loraSettings != nil {


### PR DESCRIPTION
A modified version of @sigmaroot's fix (https://github.com/TheThingsNetwork/ttn/commit/edbe65d5a9a5e04c555166a0fa0b5fb4a712c5b7) was implemented and tested on a private local instance.

MQTT subscribe output of three different tests attached:
* Original version that incorrectly falls to SF12
* JP's idea of switching between SF12 and SF9 - not working
* Sigmaroot's fix with a small modification to get it to compile - tested to use SF9 to do downlinks. ie working fix.

[TTN private downlink with modified sigmaroot fix.txt](https://github.com/TheThingsNetwork/ttn/files/3726050/TTN.private.downlink.with.modified.sigmaroot.fix.txt)
[TTN private downlink with jp fix not working.txt](https://github.com/TheThingsNetwork/ttn/files/3726051/TTN.private.downlink.with.jp.fix.not.working.txt)
[TTN private downlink on sf12.txt](https://github.com/TheThingsNetwork/ttn/files/3726052/TTN.private.downlink.on.sf12.txt)

Fixes #767