### PR TITLE
Add gRPC keep alive

### DIFF
--- a/core/component/grpc.go
+++ b/core/component/grpc.go
@@ -5,6 +5,7 @@ package component
 
 import (
 	"math"
+	"time"
 
 	"github.com/TheThingsNetwork/api/trace"
 	"github.com/TheThingsNetwork/go-utils/grpc/rpcerror"
@@ -14,6 +15,7 @@ import (
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 )
 
 func (c *Component) ServerOptions() []grpc.ServerOption {
@@ -29,6 +31,15 @@ func (c *Component) ServerOptions() []grpc.ServerOption {
 			rpcerror.StreamServerInterceptor(errors.BuildGRPCError),
 			rpclog.StreamServerInterceptor(c.Ctx),
 		)),
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime:             30 * time.Second,
+			PermitWithoutStream: true,
+		}),
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			MaxConnectionIdle: 5 * time.Minute,
+			Time:              30 * time.Second,
+			Timeout:           10 * time.Second,
+		}),
 	}
 	if c.tlsConfig != nil {
 		opts = append(opts, grpc.Creds(credentials.NewTLS(c.tlsConfig)))

--- a/core/router/gateway/schedule.go
+++ b/core/router/gateway/schedule.go
@@ -256,7 +256,7 @@ func (s *schedule) Subscribe(subscriptionID string) <-chan *router_pb.DownlinkMe
 					s.gateway.Utilization.AddTx(downlink) // FIXME: Issue #420
 				}
 				s.RLock()
-				for _, ch := range s.downlinkSubscriptions {
+				for subscriptionID, ch := range s.downlinkSubscriptions {
 					select {
 					case ch <- downlink:
 					default:


### PR DESCRIPTION
#### Changes
<!-- What are the changes made in this pull request? -->

- Added the keep alive gRPC client call option with a period of 5 minutes. We use this value in order to conform to the default [enforcement policy](https://godoc.org/google.golang.org/grpc/keepalive#EnforcementPolicy), that we may encounter on external servers.
- Added the keep alive gRPC server option with a period of 30 seconds.
- Lowered the enforcement policy of the gRPC server to 1 ping per 30 seconds. Pings can occur in the absence of an active stream.
- Removed the `grpc.WithBlock` client call option.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The periods and timeouts are smaller than what I've proposed in v3. I don't have a strong opinion/argument for one value over the other one.

Should we keep the `grpc.WithBlock` ?  Does `restartstream` depend on it ?