### PR TITLE
Export v2 devices in v3 format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/cobra v0.0.6
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.6.2
 	github.com/streadway/amqp v0.0.0-20200108173154-1c71cc93ed71
 	github.com/tj/go-elastic v0.0.0-20171221160941-36157cbbebc2

--- a/ttnctl/cmd/devices_export.go
+++ b/ttnctl/cmd/devices_export.go
@@ -100,11 +100,10 @@ var devicesExportCmd = &cobra.Command{
 			ctx.WithError(err).Fatal("Could not get existing device.")
 		}
 
-		v3dev := exportV3Device(dev, cmd.Flags())
-
 		format, _ := cmd.Flags().GetString("format")
 		switch format {
 		case "v3":
+			v3dev := exportV3Device(dev, cmd.Flags())
 			if err := json.NewEncoder(os.Stdout).Encode(v3dev); err != nil {
 				conn.Close()
 				ctx.WithError(err).Fatal("Could not export device in v3 format")
@@ -133,11 +132,10 @@ var devicesExportAllCmd = &cobra.Command{
 		}
 
 		for _, dev := range devs {
-			v3dev := exportV3Device(dev, cmd.Flags())
-
 			format, _ := cmd.Flags().GetString("format")
 			switch format {
 			case "v3":
+				v3dev := exportV3Device(dev, cmd.Flags())
 				if err := json.NewEncoder(os.Stdout).Encode(v3dev); err != nil {
 					conn.Close()
 					ctx.WithError(err).Fatal("Could not export device in v3 format")

--- a/ttnctl/cmd/devices_export.go
+++ b/ttnctl/cmd/devices_export.go
@@ -1,0 +1,163 @@
+// Copyright © 2020 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+
+	"github.com/TheThingsNetwork/api"
+	"github.com/TheThingsNetwork/api/handler"
+	"github.com/TheThingsNetwork/go-utils/log"
+	"github.com/TheThingsNetwork/ttn/ttnctl/util"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func exportV3Device(dev *handler.Device, flags *pflag.FlagSet) *v3Device {
+	v3Dev := &v3Device{}
+	v3Dev.IDs.ApplicationIDs.ApplicationID = dev.AppID
+	v3Dev.IDs.DeviceID = dev.DevID
+
+	if dev.Latitude != 0 || dev.Longitude != 0 {
+		v3Dev.Locations = map[string]v3DeviceLocation{
+			"user": {
+				Latitude:  float64(dev.Latitude),
+				Longitude: float64(dev.Longitude),
+				Altitude:  dev.Altitude,
+				Source:    "SOURCE_REGISTRY",
+			},
+		}
+	}
+
+	v3Dev.Name = dev.DevID
+	v3Dev.Description = dev.Description
+	v3Dev.Attributes = dev.Attributes
+
+	lorawanDevice := dev.GetLoRaWANDevice()
+
+	v3Dev.IDs.JoinEUI = lorawanDevice.GetAppEUI().String()
+	v3Dev.IDs.DevEUI = lorawanDevice.GetDevEUI().String()
+	if lorawanDevice.AppKey.String() != "" {
+		v3Dev.RootKeys = &v3DeviceRootKeys{
+			AppKey: v3DeviceKey{Key: lorawanDevice.AppKey.String()},
+		}
+	}
+	if devAddr := lorawanDevice.DevAddr; !devAddr.IsEmpty() && lorawanDevice.NwkSKey.String() != "" {
+		v3Dev.DevAddr = devAddr.String()
+		v3Dev.Session = &v3DeviceSession{}
+		v3Dev.Session.DevAddr = lorawanDevice.DevAddr.String()
+		if lorawanDevice.AppSKey.String() != "" {
+			v3Dev.Session.Keys.AppSKey = v3DeviceKey{Key: lorawanDevice.AppSKey.String()}
+		}
+		v3Dev.Session.Keys.FNwkSIntKey = v3DeviceKey{Key: lorawanDevice.NwkSKey.String()}
+		v3Dev.Session.LastFCntUp = lorawanDevice.FCntUp
+		v3Dev.Session.LastNFCntDown = lorawanDevice.FCntDown
+	}
+
+	v3Dev.MACSettings.Supports32BitFCnt = lorawanDevice.Uses32BitFCnt
+	v3Dev.MACSettings.ResetsFCnt = lorawanDevice.DisableFCntCheck
+
+	v3Dev.MACVersion = "MAC_V1_0_2"
+	v3Dev.PHYVersion = "PHY_V1_0_2_REV_B"
+
+	v3Dev.SupportsJoin = lorawanDevice.AppKey.String() != ""
+	v3Dev.MACSettings.Rx1Delay = "RX_DELAY_1"
+
+	frequencyPlanFlag, _ := flags.GetString("frequency-plan-id")
+	frequencyPlan, err := getOption(frequencyPlans, frequencyPlanFlag)
+	if err != nil {
+		ctx.WithError(err).WithFields(log.Fields{
+			"frequency_plan_id":            frequencyPlanFlag,
+			"available_frequency_plan_ids": frequencyPlans,
+		}).Fatal("Invalid --frequency-plan-id argument")
+	}
+	v3Dev.FrequencyPlanID = frequencyPlan
+
+	return v3Dev
+}
+
+var devicesExportCmd = &cobra.Command{
+	Use:     "export [Device ID]",
+	Short:   "Export a device",
+	Long:    `ttnctl devices export exports a device to an external format.`,
+	Example: `$ ttnctl devices export test | ttn-lw-cli end-devices create --application-id app-id`,
+	Run: func(cmd *cobra.Command, args []string) {
+		assertArgsLength(cmd, args, 1, 1)
+
+		devID := strings.ToLower(args[0])
+		if err := api.NotEmptyAndValidID(devID, "Device ID"); err != nil {
+			ctx.Fatal(err.Error())
+		}
+		appID := util.GetAppID(ctx)
+
+		conn, manager := util.GetHandlerManager(ctx, appID)
+		dev, err := manager.GetDevice(appID, devID)
+		if err != nil {
+			conn.Close()
+			ctx.WithError(err).Fatal("Could not get existing device.")
+		}
+
+		v3dev := exportV3Device(dev, cmd.Flags())
+
+		format, _ := cmd.Flags().GetString("format")
+		switch format {
+		case "v3":
+			if err := json.NewEncoder(os.Stdout).Encode(v3dev); err != nil {
+				conn.Close()
+				ctx.WithError(err).Fatal("Could not export device in v3 format")
+			}
+		}
+		conn.Close()
+	},
+}
+
+var devicesExportAllCmd = &cobra.Command{
+	Use:     "export-all",
+	Short:   "Export all devices",
+	Long:    `ttnctl devices export-all exports all devices to an external format.`,
+	Example: `$ ttnctl devices export-all | ttn-lw-cli end-devices create --application-id app-id`,
+	Run: func(cmd *cobra.Command, args []string) {
+		assertArgsLength(cmd, args, 0, 0)
+
+		appID := util.GetAppID(ctx)
+
+		conn, manager := util.GetHandlerManager(ctx, appID)
+
+		devs, err := manager.GetDevicesForApplication(appID, 0, 0)
+		if err != nil {
+			conn.Close()
+			ctx.WithError(err).Fatal("Could not get devices.")
+		}
+
+		for _, dev := range devs {
+			v3dev := exportV3Device(dev, cmd.Flags())
+
+			format, _ := cmd.Flags().GetString("format")
+			switch format {
+			case "v3":
+				if err := json.NewEncoder(os.Stdout).Encode(v3dev); err != nil {
+					conn.Close()
+					ctx.WithError(err).Fatal("Could not export device in v3 format")
+				}
+			}
+		}
+		conn.Close()
+	},
+}
+
+func v3ExportFlagSet() *pflag.FlagSet {
+	set := &pflag.FlagSet{}
+	set.String("format", "v3", "Formatting: v3")
+	set.String("frequency-plan-id", "", "Specify Frequency Plan ID")
+	return set
+}
+
+func init() {
+	devicesCmd.AddCommand(devicesExportCmd)
+	devicesCmd.AddCommand(devicesExportAllCmd)
+	devicesExportCmd.Flags().AddFlagSet(v3ExportFlagSet())
+	devicesExportAllCmd.Flags().AddFlagSet(v3ExportFlagSet())
+}

--- a/ttnctl/cmd/root.go
+++ b/ttnctl/cmd/root.go
@@ -38,9 +38,14 @@ var RootCmd = &cobra.Command{
 			logLevel = log.DebugLevel
 		}
 
+		logWriter := os.Stdout
+		if cmd == devicesExportCmd || cmd == devicesExportAllCmd {
+			logWriter = os.Stderr
+		}
+
 		ctx = apex.Wrap(&log.Logger{
 			Level:   logLevel,
-			Handler: cliHandler.New(os.Stdout),
+			Handler: cliHandler.New(logWriter),
 		})
 
 		if viper.GetBool("debug") {

--- a/ttnctl/cmd/v3types.go
+++ b/ttnctl/cmd/v3types.go
@@ -1,0 +1,99 @@
+// Copyright © 2020 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package cmd
+
+import "fmt"
+
+type v3ApplicationIDs struct {
+	ApplicationID string `json:"application_id,omitempty"`
+}
+
+type v3DeviceIDs struct {
+	DeviceID       string           `json:"device_id"`
+	ApplicationIDs v3ApplicationIDs `json:"application_ids,omitempty"`
+	DevEUI         string           `json:"dev_eui,omitempty"`
+	JoinEUI        string           `json:"join_eui,omitempty"`
+	DevAddr        string           `json:"dev_addr,omitempty"`
+}
+
+type v3DeviceLocation struct {
+	Latitude  float64 `json:"latitude,omitempty"`
+	Longitude float64 `json:"longitude,omitempty"`
+	Altitude  int32   `json:"altitude,omitempty"`
+	Source    string  `json:"source,omitempty"`
+}
+
+type v3DeviceKey struct {
+	Key string `json:"key"`
+}
+
+type v3DeviceRootKeys struct {
+	AppKey v3DeviceKey `json:"app_key,omitempty"`
+}
+
+type v3DeviceSessionKeys struct {
+	AppSKey     v3DeviceKey `json:"app_s_key,omitempty"`
+	FNwkSIntKey v3DeviceKey `json:"f_nwk_s_int_key,omitempty"`
+}
+
+type v3DeviceSession struct {
+	DevAddr       string              `json:"dev_addr"`
+	Keys          v3DeviceSessionKeys `json:"keys"`
+	LastFCntUp    uint32              `json:"last_f_cnt_up"`
+	LastNFCntDown uint32              `json:"last_n_f_cnt_down"`
+}
+
+type v3DeviceMACSettings struct {
+	Rx1Delay                 string   `json:"value,omitempty"`
+	Supports32BitFCnt        bool     `json:"supports_32_bit_f_cnt"`
+	ResetsFCnt               bool     `json:"resets_f_cnt"`
+	FactoryPresetFrequencies []uint64 `json:"factory_preset_frequencies,omitempty"`
+}
+
+type v3Device struct {
+	IDs             v3DeviceIDs                 `json:"ids"`
+	Name            string                      `json:"name,omitempty"`
+	Description     string                      `json:"description,omitempty"`
+	Attributes      map[string]string           `json:"attributes,omitempty"`
+	DevAddr         string                      `json:"dev_addr,omitempty"`
+	Locations       map[string]v3DeviceLocation `json:"locations,omitempty"`
+	MACVersion      string                      `json:"lorawan_version"`
+	PHYVersion      string                      `json:"lorawan_phy_version"`
+	FrequencyPlanID string                      `json:"frequency_plan_id"`
+	SupportsJoin    bool                        `json:"supports_join"`
+	RootKeys        *v3DeviceRootKeys           `json:"root_keys,omitempty"`
+	NetID           []byte                      `json:"net_id,omitempty"`
+	MACSettings     v3DeviceMACSettings         `json:"mac_settings"`
+	Session         *v3DeviceSession            `json:"session,omitempty"`
+}
+
+var (
+	frequencyPlans = []string{
+		"AS_920_923_LBT",
+		"AS_920_923",
+		"AS_923_925_LBT",
+		"AS_923_925_TTN_AU",
+		"AS_923_925",
+		"AU_915_928_FSB_1",
+		"AU_915_928_FSB_2",
+		"AU_915_928_FSB_6",
+		"CN_470_510_FSB_11",
+		"EU_863_870_TTN",
+		"EU_863_870",
+		"IN_865_867",
+		"KR_920_923_TTN",
+		"RU_864_870_TTN",
+		"US_902_928_FSB_1",
+		"US_902_928_FSB_2",
+	}
+)
+
+func getOption(options []string, option string) (string, error) {
+	for _, o := range options {
+		if o == option {
+			return option, nil
+		}
+	}
+	return "", fmt.Errorf("invalid_value")
+}


### PR DESCRIPTION
## Summary

Closes #764 . This is the v2 part of migrating end devices to the v3.

## Changes

- Adds `ttnctl devices export <device-id>` command
- Adds `ttnctl devices export-all` command

## Example

```
$ ttnctl devices export-all --frequency-plan-id EU_863_870 | ttn-lw-cli dev create --application-id my-v3-app
```

It is required to pass the frequency plan ID (v2 devices don't have one). We could probably pick a default one from the handler/router, but I think it's better to let the user decide.

## Review

@htdvisser please review CLI and usage. Also, running `ttnctl` locally updates some packages in `go.mod`. Not sure how to proceed with these.
@rvolosatovs please review the MAC settings