### PR TITLE
Fix Rx1Delay value in exported devices

### DIFF
--- a/ttnctl/cmd/devices_export.go
+++ b/ttnctl/cmd/devices_export.go
@@ -64,7 +64,7 @@ func exportV3Device(dev *handler.Device, flags *pflag.FlagSet) *v3Device {
 	v3Dev.PHYVersion = "PHY_V1_0_2_REV_B"
 
 	v3Dev.SupportsJoin = lorawanDevice.AppKey.String() != ""
-	v3Dev.MACSettings.Rx1Delay = "RX_DELAY_1"
+	v3Dev.MACSettings.Rx1Delay.Value = "RX_DELAY_1"
 
 	frequencyPlanFlag, _ := flags.GetString("frequency-plan-id")
 	frequencyPlan, err := getOption(frequencyPlans, frequencyPlanFlag)

--- a/ttnctl/cmd/v3types.go
+++ b/ttnctl/cmd/v3types.go
@@ -44,11 +44,15 @@ type v3DeviceSession struct {
 	LastNFCntDown uint32              `json:"last_n_f_cnt_down"`
 }
 
+type v3RxDelay struct {
+	Value string `json:"value,omitempty"`
+}
+
 type v3DeviceMACSettings struct {
-	Rx1Delay                 string   `json:"value,omitempty"`
-	Supports32BitFCnt        bool     `json:"supports_32_bit_f_cnt"`
-	ResetsFCnt               bool     `json:"resets_f_cnt"`
-	FactoryPresetFrequencies []uint64 `json:"factory_preset_frequencies,omitempty"`
+	Rx1Delay                 v3RxDelay `json:"rx1_delay,omitempty"`
+	Supports32BitFCnt        bool      `json:"supports_32_bit_f_cnt"`
+	ResetsFCnt               bool      `json:"resets_f_cnt"`
+	FactoryPresetFrequencies []uint64  `json:"factory_preset_frequencies,omitempty"`
 }
 
 type v3Device struct {


### PR DESCRIPTION
Quickfix PR that exports the Rx1Delay value correctly for v3 devices

This is a leftover from #776, after testing with actual devices.