### PR TITLE
Compile regex only once

### DIFF
--- a/core/types/data_rate.go
+++ b/core/types/data_rate.go
@@ -18,10 +18,11 @@ type DataRate struct {
 	Bandwidth       uint `json:"bandwidth,omitempty"`
 }
 
+var datarateRegex = regexp.MustCompile("SF(7|8|9|10|11|12)BW(125|250|500)")
+
 // ParseDataRate parses a 32-bit hex-encoded string to a Devdatr
 func ParseDataRate(input string) (datr *DataRate, err error) {
-	re := regexp.MustCompile("SF(7|8|9|10|11|12)BW(125|250|500)")
-	matches := re.FindStringSubmatch(input)
+	matches := datarateRegex.FindStringSubmatch(input)
 	if len(matches) != 3 {
 		return nil, errors.New("ttn/core: Invalid DataRate")
 	}

--- a/core/types/parse_hex.go
+++ b/core/types/parse_hex.go
@@ -5,9 +5,10 @@ package types
 
 import (
 	"encoding/hex"
-	"fmt"
-	"regexp"
+	"errors"
 )
+
+var errInvalidLength = errors.New("wrong input length")
 
 // ParseHEX parses a string "input" to a byteslice with length "length".
 func ParseHEX(input string, length int) ([]byte, error) {
@@ -15,14 +16,9 @@ func ParseHEX(input string, length int) ([]byte, error) {
 		return make([]byte, length), nil
 	}
 
-	pattern := regexp.MustCompile(fmt.Sprintf("^[[:xdigit:]]{%d}$", length*2))
-
-	valid := pattern.MatchString(input)
-	if !valid {
-		return nil, fmt.Errorf("Invalid input: %s is not hex", input)
+	if len(input) != length*2 {
+		return nil, errInvalidLength
 	}
 
-	slice, _ := hex.DecodeString(input)
-
-	return slice, nil
+	return hex.DecodeString(input)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This quickfix removes regex compilation on HEX decoding and data rate decoding. This is on the very hot path of `networkserver`, `handler` and `broker`.

#### Changes
<!-- What are the changes made in this pull request? -->

- Compile regex only once.
- Replace regexp check from HEX decoder with length check.

#### Testing

<!-- How did you verify that this change works? -->

Unit tests.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

![image](https://user-images.githubusercontent.com/36161392/89644358-65b67c00-d8c0-11ea-9eb5-f52fa1b38e25.png)
`networkserver` hot-path before

![image](https://user-images.githubusercontent.com/36161392/89644407-88e12b80-d8c0-11ea-978a-127339e27cc4.png)
`networkserver` hot-path after

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
