### PR TITLE
Miscellaneous router optimizations

### DIFF
--- a/core/component/auth.go
+++ b/core/component/auth.go
@@ -205,11 +205,7 @@ func (c *Component) BuildJWT() (string, error) {
 	if c.Identity == nil {
 		return "", nil
 	}
-	privPEM, err := security.PrivatePEM(c.privateKey)
-	if err != nil {
-		return "", err
-	}
-	return security.BuildJWT(c.Identity.ID, 20*time.Second, privPEM)
+	return security.BuildJWT(c.Identity.ID, 20*time.Second, c.privateKey)
 }
 
 // GetContext returns a context for outgoing RPC request. If token is "", this function will generate a short lived token from the component

--- a/core/router/downlink.go
+++ b/core/router/downlink.go
@@ -32,19 +32,7 @@ func (r *router) SubscribeDownlink(gatewayID string, subscriptionID string) (<-c
 	if token := gateway.Token(); gatewayID != "" && token != "" {
 		r.Discovery.AddGatewayID(gatewayID, token)
 	}
-	monitored := make(chan *pb.DownlinkMessage)
-	go func() {
-		for downlink := range sub {
-			monitored <- downlink
-			if gateway.MonitorStream != nil {
-				clone := *downlink // There can be multiple subscribers
-				clone.Trace = clone.Trace.WithEvent(trace.SendEvent)
-				gateway.MonitorStream.Send(&clone)
-			}
-		}
-		close(monitored)
-	}()
-	return monitored, nil
+	return sub, nil
 }
 
 func (r *router) UnsubscribeDownlink(gatewayID string, subscriptionID string) error {

--- a/core/router/server.go
+++ b/core/router/server.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	pb "github.com/TheThingsNetwork/api/router"
+	"github.com/TheThingsNetwork/api/trace"
 	"github.com/TheThingsNetwork/go-account-lib/claims"
 	"github.com/TheThingsNetwork/go-utils/grpc/ttnctx"
 	"github.com/TheThingsNetwork/ttn/api/ratelimit"
@@ -176,6 +177,11 @@ func (r *routerRPC) Subscribe(req *pb.SubscribeRequest, stream pb.Router_Subscri
 			}
 			if err := stream.Send(downlink); err != nil {
 				return err
+			}
+			if gateway.MonitorStream != nil {
+				clone := *downlink // There can be multiple subscribers
+				clone.Trace = clone.Trace.WithEvent(trace.SendEvent)
+				gateway.MonitorStream.Send(&clone)
 			}
 		}
 	}

--- a/utils/security/jwt.go
+++ b/utils/security/jwt.go
@@ -12,7 +12,7 @@ import (
 )
 
 // BuildJWT builds a JSON Web Token for the given subject and ttl, and signs it with the given private key
-func BuildJWT(subject string, ttl time.Duration, privateKey []byte) (token string, err error) {
+func BuildJWT(subject string, ttl time.Duration, key *ecdsa.PrivateKey) (token string, err error) {
 	claims := jwt.StandardClaims{
 		Issuer:    subject,
 		Subject:   subject,
@@ -23,11 +23,6 @@ func BuildJWT(subject string, ttl time.Duration, privateKey []byte) (token strin
 		claims.ExpiresAt = time.Now().Add(ttl).Unix()
 	}
 	tokenBuilder := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
-	var key *ecdsa.PrivateKey
-	key, err = jwt.ParseECPrivateKeyFromPEM(privateKey)
-	if err != nil {
-		return
-	}
 	token, err = tokenBuilder.SignedString(key)
 	if err != nil {
 		return

--- a/utils/security/jwt_test.go
+++ b/utils/security/jwt_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dgrijalva/jwt-go"
 	. "github.com/smartystreets/assertions"
 )
 
@@ -24,7 +25,10 @@ Oft1TEC43DTCN5vCSfupyBS7ZKgUUjg4E0Aq5SIJENqeRP3tTko8O3VZYQ==
 func TestJWT(t *testing.T) {
 	a := New(t)
 
-	jwt, err := BuildJWT("the-subject", time.Second, []byte(privKey))
+	key, err := jwt.ParseECPrivateKeyFromPEM([]byte(privKey))
+	a.So(err, ShouldBeNil)
+
+	jwt, err := BuildJWT("the-subject", time.Second, key)
 	a.So(err, ShouldBeNil)
 
 	claims, err := ValidateJWT(jwt, []byte(pubKey))


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR introduces a series of optimizations both in shared component code and in the router.

#### Changes
<!-- What are the changes made in this pull request? -->

- While building a JWT token, do not convert the private key to `[]byte`, then back to the `*ecdsa.PrivateKey` format. Instead, just pass the `*ecdsa.PrivateKey` directly.
- Reuse the JWT token between all of the broker requests. This is still not ideal since we should share the token between separate activations as well, but it is what it is.
- Wait only for the first successful activation downlink, instead of waiting for duplicates as well.
- Combine the router gRPC handlers with the code in [api/router/routerclient/server_streams](https://github.com/TheThingsNetwork/api/blob/master/router/routerclient/server_streams.go) in order to lower the number of active goroutines and channels. This saves us 3 goroutines per gateway. 
- Move the router downlink tracing (from `router` to `gateway`) inside the gRPC handler. This saves us one goroutine per gateway.
- Create an upper bound of concurrent downlink handlers per broker. Currently set to `64` handlers per broker. There is only one uplink handler per broker since the `api` package already does multiplexing.

#### Testing

<!-- How did you verify that this change works? -->

Unit tests.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

We save 4 goroutines per gateway with this PR, which in _large_ deployments amounts to about 20% less goroutines (wrt total amount per instance). This allows us to save a significant amount of memory and CPU costs.

This targets `update/deps` in order to separate the changes.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
