### PR TITLE
Allow clearing session keys

### DIFF
--- a/core/handler/manager_server.go
+++ b/core/handler/manager_server.go
@@ -225,7 +225,7 @@ func (h *handlerManager) SetDevice(ctx context.Context, in *pb_handler.Device) (
 		changedFields := dev.ChangedFields()
 		for _, changedField := range changedFields {
 			switch changedField {
-			case "AppKey", "UsedDevNonces", "UsedAppNonces": // Allow changing the AppKey.
+			case "AppKey", "UsedDevNonces", "UsedAppNonces", "NwkSKey", "AppSKey": // Allow changing the AppKey for OTAA and the session keys for ABP.
 			default:
 				md, _ := metadata.FromIncomingContext(ctx)
 				h.handler.Ctx.WithFields(ttnlog.Fields{

--- a/core/handler/manager_server.go
+++ b/core/handler/manager_server.go
@@ -225,7 +225,7 @@ func (h *handlerManager) SetDevice(ctx context.Context, in *pb_handler.Device) (
 		changedFields := dev.ChangedFields()
 		for _, changedField := range changedFields {
 			switch changedField {
-			case "AppKey", "UsedDevNonces", "UsedAppNonces", "NwkSKey", "AppSKey": // Allow changing the AppKey for OTAA and the session keys for ABP.
+			case "AppKey", "UsedDevNonces", "DevAddr", "UsedAppNonces", "NwkSKey", "AppSKey": // Allow changing the AppKey for OTAA and the session data for ABP.
 			default:
 				md, _ := metadata.FromIncomingContext(ctx)
 				h.handler.Ctx.WithFields(ttnlog.Fields{

--- a/core/handler/manager_server.go
+++ b/core/handler/manager_server.go
@@ -226,6 +226,7 @@ func (h *handlerManager) SetDevice(ctx context.Context, in *pb_handler.Device) (
 		for _, changedField := range changedFields {
 			switch changedField {
 			case "AppKey", "UsedDevNonces", "DevAddr", "UsedAppNonces", "NwkSKey", "AppSKey": // Allow changing the AppKey for OTAA and the session data for ABP.
+			case "FCntUp": // Allow updating the frame counters, as they may change between the moment the device is retrieved and the update itself.
 			default:
 				md, _ := metadata.FromIncomingContext(ctx)
 				h.handler.Ctx.WithFields(ttnlog.Fields{


### PR DESCRIPTION
#### Summary

Allow clearing session keys, this is needed by the migration tool.

#### Changes

- Check the changed list for `AppSKey` and `NwkSKey` and allow update.

#### Testing

🤷   let's see if this breaks anything once deployed.
